### PR TITLE
Fix undefined variable in python example within README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ snap = engine.take_snapshot()
 engine.restore_snapshot(snap)
 
 # Run the binary
-maat.run() 
+engine.run()
 ```
 
 # Contact


### PR DESCRIPTION
There's no variable named `maat` in the example.

The same issue can be found in the example at: https://maat.re/python_api/index.html