### PR TITLE
Various fixes for #54

### DIFF
--- a/bindings/python/py_memory.cpp
+++ b/bindings/python/py_memory.cpp
@@ -371,9 +371,8 @@ void init_memory(PyObject* module)
     PyDict_SetItemString(mem_enum, "RX", PyLong_FromLong(maat::mem_flag_rx));
     PyDict_SetItemString(mem_enum, "WX", PyLong_FromLong(maat::mem_flag_wx));
     PyDict_SetItemString(mem_enum, "RWX", PyLong_FromLong(maat::mem_flag_rwx));
-    PyObject* mem_class = create_class(PyUnicode_FromString("MEM"), PyTuple_New(0), mem_enum);
-    PyModule_AddObject(module, "MEM", mem_class);
-    
+    PyObject* perm_class = create_class(PyUnicode_FromString("PERM"), PyTuple_New(0), mem_enum);
+    PyModule_AddObject(module, "PERM", perm_class);
 };
 
 } // namespace py

--- a/src/env/emulated_syscalls/linux_syscalls.cpp
+++ b/src/env/emulated_syscalls/linux_syscalls.cpp
@@ -176,7 +176,7 @@ FunctionCallback::return_t _stat(
     // Order of the fields in the stat struct also come from the reverse on my own machine
     engine.mem->write(statbuf, 0x16, long_size); // st_dev
     statbuf += long_size;
-    engine.mem->write(statbuf, 0x4, long_size); // st_ino
+    engine.mem->write(statbuf, file->uuid(), long_size); // st_ino
     statbuf += long_size;
     engine.mem->write(statbuf, 0x1, long_size); // st_nlink
     statbuf += long_size;
@@ -706,6 +706,7 @@ FunctionCallback::return_t sys_linux_openat(
     int flags = args[2].as_int(*engine.vars);
     bool absolute_path = pathname[0] == '/';
     std::string filepath = "";
+
     // Get filepath
     if (absolute_path)
     {
@@ -722,6 +723,7 @@ FunctionCallback::return_t sys_linux_openat(
             throw env_exception("Emulated openat(): not supported for arbitrary dirfd");
         }
     }
+
     return linux_generic_open(engine, filepath, flags);
 }
 

--- a/src/include/maat/env/filesystem.hpp
+++ b/src/include/maat/env/filesystem.hpp
@@ -113,7 +113,9 @@ public:
         IOSTREAM, ///< Stream (reads consume data from the beginning, writes append data at the end)
         SYMLINK ///< Symbolic link to another file
     };
-
+private:
+    static unsigned int _uuid_cnt;
+    unsigned int _uuid;
 protected:
     std::shared_ptr<MemSegment> data;
     int flags;
@@ -154,7 +156,9 @@ public:
     bool is_symlink();
     /// If symlink, returns the file it points to
     const std::string& symlink();
-
+public:
+    /// Return the file uuid
+    unsigned int uuid();
 private:
     // Used by streams
     void _adjust_read_offset(addr_t& offset);

--- a/src/include/maat/env/library.hpp
+++ b/src/include/maat/env/library.hpp
@@ -55,11 +55,24 @@ public:
     FunctionCallback& operator=(FunctionCallback&& other) = default; ///< Move assignment
     ~FunctionCallback();
 public:
-    /// Run the function callback assuming abi *abi*
-    env::Action execute(MaatEngine& engine, const abi::ABI& abi) const;
+    /** Run the function callback
+    * 
+    * @param abi ABI to use to get function arguments and return from the function
+    * @param func_wrapper_name Optional function name to use to log the function call. If
+    * unspecified the call will not be logged
+    */
+    env::Action execute(
+        MaatEngine& engine,
+        const abi::ABI& abi,
+        std::optional<std::string> func_wrapper_name = std::nullopt
+    ) const;
 private:
     /// Execute native callback
-    env::Action _execute_native(MaatEngine& engine, const abi::ABI& abi) const;
+    env::Action _execute_native(
+        MaatEngine& engine,
+        const abi::ABI& abi,
+        std::optional<std::string> func_wrapper_name = std::nullopt
+    ) const;
     /// Execute python callack
     env::Action _execute_python(MaatEngine& engine, const abi::ABI& abi) const;
 };

--- a/src/loader/loader_lief_elf.cpp
+++ b/src/loader/loader_lief_elf.cpp
@@ -663,11 +663,13 @@ void LoaderLIEF::load_elf_interpreter(
     std::string interp_name = _clean_interpreter_name(top_loader._elf->interpreter());
 
     // Parse binary with LIEF
+    // Note(boyan):
     interp_loader.parse_binary(interp_path, Format::ELF32);
 
     // Find available base address
     uint64_t vsize = interp_loader._elf->virtual_size();
-    addr_t base_address = find_free_space(engine, 0x1000, vsize);
+    addr_t heap_size = 0x400000;
+    addr_t base_address = find_free_space(engine, 0x1000, vsize+heap_size);
     if (base_address == 0)
     {
         throw loader_exception(
@@ -690,7 +692,6 @@ void LoaderLIEF::load_elf_interpreter(
         *engine->mem,
         interp_loader.binary_name
     );
-    addr_t heap_size = 0x400000;
     engine->mem->map(
         heap_base,
         heap_base+heap_size-1,


### PR DESCRIPTION
This PR fixes some issues related to #54 and adds a few improvements added while debugging the issue:
- adds a `uuid` to physical files in the symbolic filesystem
- fixes the Linux `stat` syscall by using file `uuid`s for the `st_ino` field (inode number)
- fixes reserving space to map the interpreter in ELF loader
- fixes bug while processing file path in symbolic filesystem  