### PR TITLE
Test sleigh fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,15 +102,17 @@ jobs:
       - name: Install Dependencies
         if: matrix.target_arch == 'arm64'
         run: |
-          wget -O - -c https://github.com/lief-project/LIEF/releases/download/0.11.5/LIEF-0.11.5-Darwin-arm64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
+          mkdir -p "${{ github.workspace }}/arm64-cross"
+          wget -O - -c https://github.com/lief-project/LIEF/releases/download/0.11.5/LIEF-0.11.5-Darwin-arm64.tar.gz | tar xz -C "${{ github.workspace }}/arm64-cross" --strip-components=1
 
-          wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz && mkdir -p gmp/build && tar xzvf gmp-6.2.1.tar.lz -C gmp --strip-components 1
-          cd gmp/build && ../configure --enable-shared --disable-static CFLAGS='-target arm64-apple-macos11' CXXFLAGS='-target arm64-apple-macos11' --host arm64-apple-macos11  --build=aarch64-apple-macos11 --disable-assembly --enable-cxx
-          make && sudo make install
+          wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz && mkdir -p gmp/build && tar --lzip -xvf gmp-6.2.1.tar.lz -C gmp --strip-components 1
+          cd gmp/build && ../configure --enable-shared --disable-static CFLAGS='-arch arm64 -mmacosx-version-min=11.0' CXXFLAGS='-arch arm64 -mmacosx-version-min=11.0' LDFLAGS='-arch arm64 -mmacosx-version-min=11.0' --build=x86_64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-apple-darwin --disable-assembly --enable-cxx "--prefix=${{ github.workspace }}/arm64-cross"
+          make && make install
+          cd ../../
 
-          wget -O z3.tar.gz https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz && mkdir -p z3/build && tar xzvf z3.tar.gz -C z3 --strip-components 1
-          cd z3/build && CFLAGS="-target aarch64-apple-macos11" CXXFLAGS="-target aarch64-apple-macos11" cmake -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_LIBZ3_SHARED=NO -DZ3_BUILD_EXECUTABLE=FALSE -DZ3_BUILD_TEST_EXECUTABLES=FALSE -DZ3_ENABLE_EXAMPLE_TARGETS=FALSE ..
-          make -j4 && make install
+          wget -O z3.tar.gz https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz && mkdir z3 && tar xzvf z3.tar.gz -C z3 --strip-components 1
+          cmake -B z3/build -S z3 -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_LIBZ3_SHARED=NO -DZ3_BUILD_EXECUTABLE=FALSE -DZ3_BUILD_TEST_EXECUTABLES=FALSE -DZ3_ENABLE_EXAMPLE_TARGETS=FALSE
+          cmake --build z3/build -j4 && cmake --install z3/build --prefix "${{ github.workspace }}/arm64-cross"
 
           # Native sleigh for running the sleigh compiler
           wget -O - -c https://github.com/lifting-bits/sleigh/releases/download/v10.1.2/macOS-sleigh-10.1.2-1.x86_64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
@@ -120,9 +122,11 @@ jobs:
         if: matrix.target_arch == 'arm64'
         # Force macOS target version for C++17 support
         run: |
-          export MACOSX_DEPLOYMENT_TARGET=10.15
-          export CFLAGS='-target arm64-apple-macos11'
-          export CXXFLAGS='-target arm64-apple-macos11'
+          export "CMAKE_PREFIX_PATH=${{ github.workspace }}/arm64-cross"
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          export CFLAGS='-arch arm64 -mmacosx-version-min=11.0'
+          export CXXFLAGS='-arch arm64 -mmacosx-version-min=11.0'
+          export LDFLAGS='-arch arm64 -mmacosx-version-min=11.0'
           python3 -m cibuildwheel --output-dir wheelhouse bindings/packaging
         env:
           MAAT_SLEIGH_COMPILER: "/usr/local/bin/sleigh_opt"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -105,11 +105,11 @@ jobs:
           wget -O - -c https://github.com/lief-project/LIEF/releases/download/0.11.5/LIEF-0.11.5-Darwin-arm64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
 
           wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz && mkdir -p gmp/build && tar xzvf gmp-6.2.1.tar.lz -C gmp --strip-components 1
-          cd gmp/build && ../configure CFLAGS='-target arm64-apple-macos11' CXXFLAGS='-target arm64-apple-macos11' --host arm64-apple-macos11  --build=aarch64-apple-macos11 --disable-assembly --enable-cxx
+          cd gmp/build && ../configure --enable-shared --disable-static CFLAGS='-target arm64-apple-macos11' CXXFLAGS='-target arm64-apple-macos11' --host arm64-apple-macos11  --build=aarch64-apple-macos11 --disable-assembly --enable-cxx
           make && sudo make install
 
           wget -O z3.tar.gz https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz && mkdir -p z3/build && tar xzvf z3.tar.gz -C z3 --strip-components 1
-          cd z3/build && CFLAGS="-target aarch64-apple-macos11" CXXFLAGS="-target aarch64-apple-macos11" cmake -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_EXECUTABLE=FALSE -DZ3_BUILD_TEST_EXECUTABLES=FALSE -DZ3_ENABLE_EXAMPLE_TARGETS=FALSE ..
+          cd z3/build && CFLAGS="-target aarch64-apple-macos11" CXXFLAGS="-target aarch64-apple-macos11" cmake -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_LIBZ3_SHARED=NO -DZ3_BUILD_EXECUTABLE=FALSE -DZ3_BUILD_TEST_EXECUTABLES=FALSE -DZ3_ENABLE_EXAMPLE_TARGETS=FALSE ..
           make -j4 && make install
 
           # Native sleigh for running the sleigh compiler

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,6 +112,10 @@ jobs:
           cd z3/build && CFLAGS="-target aarch64-apple-macos11" CXXFLAGS="-target aarch64-apple-macos11" cmake -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_EXECUTABLE=FALSE -DZ3_BUILD_TEST_EXECUTABLES=FALSE -DZ3_ENABLE_EXAMPLE_TARGETS=FALSE ..
           make -j4 && make install
 
+          # Native sleigh for running the sleigh compiler
+          wget -O - -c https://github.com/lifting-bits/sleigh/releases/download/v10.1.2/macOS-sleigh-10.1.2-1.x86_64.tar.gz | sudo tar xz -C /usr/local --strip-components=1
+
+
       - name: Build wheels
         if: matrix.target_arch == 'arm64'
         # Force macOS target version for C++17 support
@@ -121,6 +125,7 @@ jobs:
           export CXXFLAGS='-target arm64-apple-macos11'
           python3 -m cibuildwheel --output-dir wheelhouse bindings/packaging
         env:
+          MAAT_SLEIGH_COMPILER: "/usr/local/bin/sleigh_opt"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: cp38-macosx_arm64 # TODO(boyan): add other python versions
           CIBW_ARCHS_MACOS: "arm64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,12 +143,26 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E make_directory "${spec_log_dir}"
 )
 
+# Allow user to override sleigh compiler to support cross-compilation. Default
+# location is the one imported when we found the sleigh package
+if(CMAKE_CROSSCOMPILING)
+  find_program(maat_SLEIGH_COMPILER "sleigh_opt"
+    DOC "Sleigh compiler executable"
+  )
+  if(NOT maat_SLEIGH_COMPILER)
+    message(FATAL_ERROR "Maat needs a sleigh compiler. Specify path manually by setting 'maat_SLEIGH_COMPILER'")
+  endif()
+else()
+  set(maat_SLEIGH_COMPILER "$<TARGET_FILE:sleigh::sleigh_opt>" CACHE PATH "Sleigh compiler executable")
+endif()
+
 macro(maat_sleigh_compile ARCH_DIR ARCH)
   # ARCH_DIR is the directory that appears in Ghidra's source code hierarchy
   # ARCH appears in the name of the '.slaspec' and '.pspec' file (they should be the same)
   # Creates a target maat_sleigh_spec_${ARCH}
   sleigh_compile(
     TARGET maat_sleigh_spec_${ARCH}
+    COMPILER "${maat_SLEIGH_COMPILER}"
     SLASPEC "${spec_dir}/${ARCH_DIR}/data/languages/${ARCH}.slaspec"
     LOG_FILE "${PROJECT_BINARY_DIR}/sleigh-log/${ARCH}.log"
     OUT_FILE "${spec_out_dir}/${ARCH}.sla"

--- a/bindings/packaging/setup.py
+++ b/bindings/packaging/setup.py
@@ -11,8 +11,12 @@ source_dir = str(Path(".").absolute().parent.parent)
 additional_cmake_configure_options = []
 
 sleigh_compiler = os.getenv("MAAT_SLEIGH_COMPILER")
-if sleigh_compiler is not None:
+if sleigh_compiler:
     additional_cmake_configure_options += [f"-Dmaat_SLEIGH_COMPILER:PATH={sleigh_compiler}"]
+
+prefix_path = os.getenv("CMAKE_PREFIX_PATH")
+if prefix_path:
+    additional_cmake_configure_options += [f"-DCMAKE_PREFIX_PATH:PATH={prefix_path}"]
 
 setup(
     cmdclass=dict(

--- a/bindings/packaging/setup.py
+++ b/bindings/packaging/setup.py
@@ -1,5 +1,4 @@
 import os
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -8,6 +7,12 @@ import cmake_build_extension
 from setuptools import setup
 
 source_dir = str(Path(".").absolute().parent.parent)
+
+additional_cmake_configure_options = []
+
+sleigh_compiler = os.getenv("MAAT_SLEIGH_COMPILER")
+if sleigh_compiler is not None:
+    additional_cmake_configure_options += [f"-Dmaat_SLEIGH_COMPILER:PATH={sleigh_compiler}"]
 
 setup(
     cmdclass=dict(
@@ -29,7 +34,7 @@ setup(
                 "-Dmaat_USE_EXTERNAL_SLEIGH=OFF",
                 "-Dmaat_BUILD_PYTHON_BINDINGS:BOOL=ON",
                 "-Dmaat_PYTHON_PACKAGING:BOOL=ON",
-            ]
+            ] + additional_cmake_configure_options
         )
     ],
 )


### PR DESCRIPTION
I got some errors during wheel repair when Z3 was linked dynamically (https://github.com/trailofbits/maat/runs/5435144478?check_suite_focus=true#step:8:1520), so I decided the easiest thing was to just statically link everything, which should also result in a smaller release size.

Regular C++ CI runs will fail because the release CMake of sleigh isn't compatible, but this is to test the Python wheel builds. 