### PR TITLE
Limit code size to lift to the end of the memory map containing the code

### DIFF
--- a/src/include/maat/memory.hpp
+++ b/src/include/maat/memory.hpp
@@ -371,8 +371,8 @@ public:
 
     /** \brief Map memory from 'start' to 'end' (included), with permissions 'mflags'. 
     Necessary segments are created in order to fill the map. The map is NOT initialised with zeros */
-    void map(addr_t start, addr_t end, mem_flag_t mflags, const std::string& map_name);
-    /** \brief Allocate a new memory map of 'size' bytes. The map will
+    void map(addr_t start, addr_t end, mem_flag_t mflags = mem_flag_rwx, const std::string& map_name = "");
+    /** \brief Allocate a new memory map of 'size' bytes. The map wills
      * be aligned according to the 'align' value. Returns the start address of the map */
     addr_t allocate(
         addr_t init_base, addr_t size, addr_t align,

--- a/src/include/maat/memory.hpp
+++ b/src/include/maat/memory.hpp
@@ -117,7 +117,7 @@ public:
     void write(offset_t off, const Number& val, int nb_bytes);
     void write_buffer(offset_t off, uint8_t* buf, int buf_len);
 
-    /** \brief Returns the closest offset from 'start' and before 'end' which 
+    /** \brief Returns the closest offset from 'start' and before 'end' (included) which 
      * holds a value different from 'val' */
     offset_t is_identical_until(offset_t start, offset_t end, uint8_t val);
 

--- a/src/memory/memory.cpp
+++ b/src/memory/memory.cpp
@@ -524,10 +524,14 @@ void MemConcreteBuffer::extend_before(addr_t nb_bytes)
 offset_t MemConcreteBuffer::is_identical_until(offset_t start, offset_t end, uint8_t val)
 {
     offset_t tmp = start;
+
+    if (start == end)
+        return start;
+
     while( *(uint8_t*)((uint8_t*)_mem+(tmp)) == val)
     {
         tmp++;
-        if( tmp > end )
+        if (tmp >= end)
             break;
     };
     return tmp;
@@ -786,7 +790,7 @@ void MemSegment::symbolic_ptr_read(Value& result, const Expr& addr, ValueSet& ad
         if( _bitmap.is_concrete(a-start))
         {
             a2 = is_identical_until(a, _concrete.read(a-start, 1)) -1; // a2 == last address containing the byte "byte"
-            if( a2 >= a-1+nb_bytes )
+            if (a2 >= a-1+nb_bytes)
             {
                 // Identical memory region bigger than single read so
                 // use interval instead
@@ -1106,16 +1110,16 @@ addr_t MemSegment::is_abstract_until(addr_t addr1, addr_t max)
 
 addr_t MemSegment::is_concrete_until(addr_t addr1, addr_t max)
 {
-    addr_t adjusted_max = (max < end-start)? max: end-start;
+    addr_t adjusted_max = (max < end-addr1)? max: end-addr1;
     return start + _bitmap.is_concrete_until(addr1-start, adjusted_max);
 }
 
 // Return first address where the byte is different than "byte"
 addr_t MemSegment::is_identical_until(addr_t addr, cst_t byte)
 {
-    addr_t max_addr = is_concrete_until(start, end);
-    addr_t res = _concrete.is_identical_until(addr-start, max_addr-start, (uint8_t)byte);
-    return res + start;
+    addr_t max_addr = is_concrete_until(addr, end-addr+1);
+    addr_t offset = _concrete.is_identical_until(addr-start, max_addr-start, (uint8_t)byte);
+    return offset + start;
 }
 
 

--- a/tests/adv-tests/test_coverage.cpp
+++ b/tests/adv-tests/test_coverage.cpp
@@ -161,12 +161,12 @@ namespace code_coverage{
             MaatEngine engine(Arch::Type::X86);
             engine.log.set_level(Log::ERROR);
             bool success;
-            engine.mem->new_segment(0x0, 0xfff);
-            engine.mem->new_segment(0x4000, 0x5fff); // stack
+            engine.mem->map(0x0, 0xfff);
+            engine.mem->map(0x4000, 0x5fff); // stack
             engine.cpu.ctx().set(X86::ESP, 0x5000);
             engine.mem->write(0x5004, 0x6000, 4); // argument of the function pushed on the stack
             engine.cpu.ctx().set(X86::EAX, 0x6000);
-            engine.mem->new_segment(0x6000, 0x6100); // The input password
+            engine.mem->map(0x6000, 0x6100); // The input password
 
             // Make user supplied password symbolic
             engine.mem->write(0x6000, exprvar(8, "char0"));
@@ -249,12 +249,12 @@ namespace code_coverage{
             engine.log.set_level(Log::ERROR);
             bool success;
             
-            engine.mem->new_segment(0x0, 0xfff);
-            engine.mem->new_segment(0x4000, 0x5fff); // stack
+            engine.mem->map(0x0, 0xfff);
+            engine.mem->map(0x4000, 0x5fff); // stack
             engine.cpu.ctx().set(X86::ESP, exprcst(32, 0x5000));
             engine.mem->write(0x5004, exprcst(32, 0x6000)); // argument of the function pushed on the stack
             engine.cpu.ctx().set(X86::EAX, exprcst(32, 0x6000));
-            engine.mem->new_segment(0x6000, 0x6100); // The input password
+            engine.mem->map(0x6000, 0x6100); // The input password
             
             /* Make user supplied password symbolic */
             engine.mem->write(0x6000, exprvar(8, "char0"));

--- a/tests/adv-tests/test_hash.cpp
+++ b/tests/adv-tests/test_hash.cpp
@@ -78,12 +78,12 @@ namespace hash
                    0x000005a5 <+56>:	leave
                    0x000005a6 <+57>:	ret
         */
-        
+
         // code
-        engine.mem->new_segment(0x0, 0xfff);
+        engine.mem->map(0x0, 0xfff);
         engine.mem->write_buffer(0x56d, code, 58);
         // stack
-        engine.mem->new_segment(0x3000, 0xffff);
+        engine.mem->map(0x3000, 0xffff);
 
         nb += _x86_assert_algo_1(engine, 0, 0x219e5c12);
         nb += _x86_assert_algo_1(engine, 100, 0x6f8cdcd6);
@@ -232,7 +232,7 @@ namespace hash
             throw test_exception();
         }
         
-        engine.mem->new_segment(0x8048950, 0x8050000);
+        engine.mem->map(0x8048950, 0x8050000);
         engine.mem->write_buffer(0x8048960, (uint8_t*)string(buffer.begin(), buffer.end()).c_str(), size);
 
         // memcpy function at address 0x806ae50
@@ -246,7 +246,7 @@ namespace hash
             throw test_exception();
         }
 
-        engine.mem->new_segment(0x806ae50, 0x8070000);
+        engine.mem->map(0x806ae50, 0x8070000);
         engine.mem->write_buffer(0x806ae50, (uint8_t*)string(buffer.begin(), buffer.end()).c_str(), size);
 
         // many data sections
@@ -260,13 +260,13 @@ namespace hash
             cout << "\nFailed to get ressource to launch tests !" << endl << std::flush; 
             throw test_exception(); 
         }
-        engine.mem->new_segment(0x80a0000, 0x80df000);
+        engine.mem->map(0x80a0000, 0x80df000);
         engine.mem->write_buffer(0x80ab000, (uint8_t*)string(buffer.begin(), buffer.end()).c_str(), size);
 
         // stack
-        engine.mem->new_segment(0xffff0000, 0xffffe000);
+        engine.mem->map(0xffff0000, 0xffffe000);
         // argument to hash
-        engine.mem->new_segment(0x11000, 0x12000);
+        engine.mem->map(0x11000, 0x12000);
 
         nb += _x86_assert_md5(engine, (char*)"msul", 0xec04d6b3, 0xf4d9196c, 0x9015e930, 0xbb668ece);
         nb += _x86_assert_md5(engine, (char*)"ixtykuaw", 0xfadace91, 0x86a333a8, 0xce0cc2f0, 0x97524cdc);
@@ -357,10 +357,10 @@ namespace hash
         /*
 
         // code
-        sym.mem->new_segment(0x0, 0x1000, MEM_FLAG_RWX);
+        sym.mem->map(0x0, 0x1000, MEM_FLAG_RWX);
         sym.mem->write_buffer(0x68a, code, 74);
         // stack
-        sym.mem->new_segment(0xfff0000000003000, 0xfff0000000010000, MEM_FLAG_RW);
+        sym.mem->map(0xfff0000000003000, 0xfff0000000010000, MEM_FLAG_RW);
 
         // Do test
         nb += _x64_assert_algo_3(sym, 100, 0xdd2f8d0fbfacdd87);

--- a/tests/adv-tests/test_hash_solving.cpp
+++ b/tests/adv-tests/test_hash_solving.cpp
@@ -94,11 +94,11 @@ namespace solve_hash{
         */
         
         // code
-        engine.mem->new_segment(0x0, 0x1000);
+        engine.mem->map(0x0, 0x1000);
         engine.mem->write_buffer(0x56d, code, 43);
         // stack
-        engine.mem->new_segment(0x3000, 0x10000);
-        
+        engine.mem->map(0x3000, 0x10000);
+
         nb += _x86_assert_algo_2(engine, _x86_revert_hash_algo_2(engine, 0x9c594849), 0x9c594849);
         nb += _x86_assert_algo_2(engine, _x86_revert_hash_algo_2(engine, 0x9cdd4849), 0x9cdd4849);
         nb += _x86_assert_algo_2(engine, _x86_revert_hash_algo_2(engine, 0x9d514849), 0x9d514849);

--- a/tests/unit-tests/test_archX64.cpp
+++ b/tests/unit-tests/test_archX64.cpp
@@ -2599,9 +2599,9 @@ void test_archX64(){
          << " Testing arch X64 support... " << std::flush;
 
     MaatEngine engine(Arch::Type::X64);
-    engine.mem->new_segment(0x0, 0x11000);
-    engine.mem->new_segment(0x110000, 0x130000);
-    engine.mem->new_segment(0x123400000000, 0x123400003000);
+    engine.mem->map(0x0, 0x11000);
+    engine.mem->map(0x110000, 0x130000);
+    engine.mem->map(0x123400000000, 0x123400003000);
 
     total += reg_translation();
     /* 

--- a/tests/unit-tests/test_archX86.cpp
+++ b/tests/unit-tests/test_archX86.cpp
@@ -48,7 +48,7 @@ namespace test
         {
             string code;
             MaatEngine sym = MaatEngine(Arch::Type::X86);
-            sym.mem->new_segment(0x1000, 0x2000);
+            sym.mem->map(0x1000, 0x2000);
             code = string("\x11\xD8", 2); // adc eax, ebx
             sym.mem->write_buffer(0x1150, (uint8_t*)code.c_str(), 2);
             code = string("\x66\x0F\x38\xF6\xC3", 5); // adcx eax, ebx
@@ -9091,8 +9091,8 @@ void test_archX86(){
     cout << bold << "[" << green << "+" << def << bold << "]" << def << std::left << std::setw(34) << " Testing arch X86 support... " << std::flush;  
 
     MaatEngine engine(Arch::Type::X86);
-    engine.mem->new_segment(0x0, 0x11000);
-    engine.mem->new_segment(0x110000, 0x130000);
+    engine.mem->map(0x0, 0x11000);
+    engine.mem->map(0x110000, 0x130000);
 
     total += reg_translation();
 

--- a/tests/unit-tests/test_event.cpp
+++ b/tests/unit-tests/test_event.cpp
@@ -495,9 +495,9 @@ using namespace test::events;
 void test_events()
 {
     maat::MaatEngine engine(maat::Arch::Type::NONE);
-    engine.mem->new_segment(0x60000, 0x70000);
-    engine.mem->new_segment(0x120000, 0x124000);
-    engine.mem->new_segment(0x0, 0x2000);
+    engine.mem->map(0x60000, 0x70000);
+    engine.mem->map(0x120000, 0x124000);
+    engine.mem->map(0x0, 0x2000);
 
     unsigned int total = 0;
     std::string green = "\033[1;32m";

--- a/tests/unit-tests/test_memory.cpp
+++ b/tests/unit-tests/test_memory.cpp
@@ -370,8 +370,8 @@ namespace test{
             std::shared_ptr<VarContext> ctx = std::make_shared<VarContext>(0);
             MemEngine mem(ctx, 64);
 
-            mem.new_segment(0x1000, 0x1fff, maat::mem_flag_rw);
-            mem.new_segment(0x3000, 0x5fff, maat::mem_flag_rwx);
+            mem.map(0x1000, 0x1fff, maat::mem_flag_rw);
+            mem.map(0x3000, 0x5fff, maat::mem_flag_rwx);
 
             mem_alert_t alert;
             Expr    e1 = exprvar(8, "var1", Taint::TAINTED),
@@ -445,7 +445,7 @@ namespace test{
             /* Test the make_symbolic, make_tainted interface */
             std::string name;
             std::stringstream ss;
-            mem.new_segment(0x6000, 0x7000);
+            mem.map(0x6000, 0x7000);
             
             // Make symbolic
             name = mem.make_symbolic(0x6000, 4, 4, "buffer0");
@@ -487,7 +487,7 @@ namespace test{
             std::shared_ptr<VarContext> ctx = std::make_shared<VarContext>(0);
             MemEngine mem(ctx, 64);
 
-            mem.new_segment(0x1000, 0x1fff, maat::mem_flag_rw);
+            mem.map(0x1000, 0x1fff, maat::mem_flag_rw);
             mem.write(0x1000, 0x12345678deadbeef, 8);
             mem.write(0x1008, 0xaaaabbbbccccdddd, 8);
             
@@ -536,8 +536,8 @@ namespace test{
             std::shared_ptr<VarContext> ctx = std::make_shared<VarContext>(0);
             MemEngine mem(ctx, 64);
 
-            mem.new_segment(0x1000, 0x1fff, maat::mem_flag_rwx);
-            mem.new_segment(0x2000, 0x2fff, maat::mem_flag_rwx);
+            mem.map(0x1000, 0x1fff, maat::mem_flag_rwx);
+            mem.map(0x2000, 0x2fff, maat::mem_flag_rwx);
 
             // With concrete write
             mem.write(0x1ffe, 0x12345678deadbeef, 8);

--- a/tests/unit-tests/test_snapshot.cpp
+++ b/tests/unit-tests/test_snapshot.cpp
@@ -39,7 +39,7 @@ namespace test
             engine.vars->set("var0", 0x41414141);
             engine.cpu.ctx().set(0, e1);
             engine.cpu.ctx().set(1, e2);
-            engine.mem->new_segment(0x2000, 0x2fff);
+            engine.mem->map(0x2000, 0x2fff);
             engine.mem->write(0x21b4, e2);
             
             // Snapshot
@@ -49,8 +49,8 @@ namespace test
             engine.mem->write(0x21b6, c1);
             engine.mem->write(0x21b4, e1);
             //  Create some segments
-            engine.mem->new_segment(0x3000, 0x3fff);
-            engine.mem->new_segment(0x5000, 0x5fff);
+            engine.mem->map(0x3000, 0x3fff);
+            engine.mem->map(0x5000, 0x5fff);
             engine.restore_snapshot(s1);
             // Rewind
             nb += _assert(engine.mem->read(0x21b4, 8).as_expr()->eq(e2), "SnapshotManager rewind failed to reset engine.memory correctly"); 
@@ -96,8 +96,8 @@ namespace test
             nb += _assert(engine.mem->read(0x2300, 8).as_expr()->eq(concat( exprcst(16, 0x1234), concat(e1, extract(e2, 63, 48)))), "SnapshotManager: rewind failed for mixed symbolic and concrete writes");
             
             //  Create some segments to test snapshot on overlapping memory accesses
-            engine.mem->new_segment(0x3000, 0x3fff);
-            engine.mem->new_segment(0x4000, 0x5fff);
+            engine.mem->map(0x3000, 0x3fff);
+            engine.mem->map(0x4000, 0x5fff);
             engine.mem->write(0x3ffd, 0xabcdef11deadbeef, 8);
             engine.take_snapshot();
             engine.mem->write(0x3ffc, e2);
@@ -138,11 +138,11 @@ namespace test
             engine.cpu.ctx().set(X86::EDX, exprcst(32, 4));
             engine.cpu.ctx().set(X86::ESP, exprcst(32, 0x4000));
 
-            engine.mem->new_segment(0x0000, 0x3fff);
+            engine.mem->map(0x0000, 0x3fff);
             engine.mem->write(0x2000, exprcst(32, 0x12345678));
             engine.mem->write(0x3000, exprcst(32, 0x87654321));
 
-            engine.mem->new_segment(0x5000, 0x50ff);
+            engine.mem->map(0x5000, 0x50ff);
             engine.mem->write_buffer(0x5000, code, sizeof(code));
 
             /* Set breakpoint */

--- a/tests/unit-tests/test_symbolic_memory.cpp
+++ b/tests/unit-tests/test_symbolic_memory.cpp
@@ -112,7 +112,7 @@ namespace test{
             auto varctx = std::make_shared<VarContext>();
             Settings settings;
             MemEngine mem(varctx, 32);
-            mem.new_segment(0x0, 0x20000, maat::mem_flag_rwx);
+            mem.map(0x0, 0x20000, maat::mem_flag_rwx);
             Expr addr1 = exprvar(32, "var_0") & 0xffff,
                  addr2 = exprvar(32, "var_1") | 0x00000100;
             Expr val1 = exprcst(32, 0x12345678);
@@ -140,7 +140,7 @@ namespace test{
             auto varctx = std::make_shared<VarContext>();
             MemEngine mem(varctx, 32);
             Settings settings;
-            mem.new_segment(0x0, 0x100000, maat::mem_flag_rwx);
+            mem.map(0x0, 0x100000, maat::mem_flag_rwx);
 
             Expr addr1 = exprvar(32, "var_0") & 0x0000ff00,
                  addr2 = exprvar(32, "var_1") | 0x00001100;
@@ -254,7 +254,7 @@ namespace test{
             auto varctx = std::make_shared<VarContext>(0);
             MemEngine mem(varctx, 64);
             Settings settings;
-            mem.new_segment(0x0, 0x100000, maat::mem_flag_rwx);
+            mem.map(0x0, 0x100000, maat::mem_flag_rwx);
             Expr addr1 = exprvar(64, "var_0") & 0x000001f,
                  addr2 = exprvar(64, "var_1") | 0x00001100;
             Expr e, ite, ite2;


### PR DESCRIPTION
Fixes #75 