### PR TITLE
Fail CI if build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         -D BUILD_SHARED_LIBS=${{ matrix.shared }}
 
     - name: Build
-      run: cmake --build build --config Release -j 2 || true
+      run: cmake --build build --config Release -j 2
 
     - name: Install
       run: cmake --install build --config Release --prefix prefix


### PR DESCRIPTION
Small thing I just noticed. If it doesn't fail at the build, it fails at install time, which makes things less clear when trying to determine failures.