### PR TITLE
Support register aliasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include(cmake/variables.cmake)
 add_library(maat_maat
   src/arch/arch_X86.cpp
   src/arch/lifter.cpp
+  src/arch/register_aliases.cpp
   src/engine/callother.cpp
   src/engine/engine.cpp
   src/engine/event.cpp

--- a/src/arch/arch_X86.cpp
+++ b/src/arch/arch_X86.cpp
@@ -1,5 +1,6 @@
 #include "maat/arch.hpp"
 #include "maat/exception.hpp"
+#include "maat/cpu.hpp"
 
 namespace maat
 {
@@ -136,7 +137,8 @@ namespace X86
             {"st4", ST4},
             {"st5", ST5},
             {"st6", ST6},
-            {"st7", ST7}
+            {"st7", ST7},
+            {"eflags", EFLAGS}
         };
     }
 
@@ -223,6 +225,8 @@ namespace X86
             case ST6:
             case ST7:
                 return 80;
+            case EFLAGS:
+                return 32;
             default:
                 throw runtime_exception("ArchX86::reg_size(): got unsupported reg num");
         }
@@ -243,6 +247,8 @@ namespace X86
         return X86::TSC;
     }
 } // namespace X86
+
+
 
 
 namespace X64
@@ -338,7 +344,8 @@ namespace X64
             {"st6", ST6},
             {"st7", ST7},
             {"mxcsr", MXCSR},
-            {"ssp", SSP}
+            {"ssp", SSP},
+            {"rflags", RFLAGS}
         };
     }
 
@@ -444,6 +451,8 @@ namespace X64
             case ST6:
             case ST7:
                 return 80;
+            case RFLAGS:
+                return 64;
             default:
                 throw runtime_exception("ArchX64::reg_size(): got unsupported reg num");
         }
@@ -464,6 +473,6 @@ namespace X64
         return X64::TSC;
     }
 } // namespace X64
-    
+
 } // namespace maat
 

--- a/src/arch/register_aliases.cpp
+++ b/src/arch/register_aliases.cpp
@@ -7,7 +7,7 @@ namespace ir{
 inline void _set_flag_from_bit(CPUContext& ctx, ir::reg_t reg, const Value& val, int bit, int nb_bits=1)
 __attribute__((always_inline))
 {
-    ctx.set(reg, concat(Value(8-nb_bits, 0), extract(val, nb_bits-1, 0)));
+    ctx.set(reg, concat(Value(8-nb_bits, 0), extract(val, nb_bits-1+bit, bit)));
 }
 
 void x86_alias_setter(CPUContext& ctx, ir::reg_t reg, const Value& val)
@@ -36,33 +36,33 @@ void x86_alias_setter(CPUContext& ctx, ir::reg_t reg, const Value& val)
         throw runtime_exception("x86_alias_setter: got unsupported register");
 }
 
-Value x86_alias_getter(const CPUContext& ctx, ir::reg_t reg)
+Value x86_alias_getter(CPUContext& ctx, ir::reg_t reg)
 {
     Value res;
     if (reg == X86::EFLAGS)
     {
         res = extract(ctx.get(X86::CF),0,0);
-        res.set_concat(res, Value(1,1));
-        res.set_concat(res, extract(ctx.get(X86::PF),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X86::AF),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X86::ZF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::SF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::TF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::IF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::DF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::OF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::IOPL),1,0));
-        res.set_concat(res, extract(ctx.get(X86::NT),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X86::RF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::VM),0,0));
-        res.set_concat(res, extract(ctx.get(X86::AC),0,0));
-        res.set_concat(res, extract(ctx.get(X86::VIF),0,0));
-        res.set_concat(res, extract(ctx.get(X86::VIP),0,0));
-        res.set_concat(res, extract(ctx.get(X86::ID),0,0));
-        res.set_concat(res, Value(10,0));
+        res.set_concat(Value(1,1), res);
+        res.set_concat(extract(ctx.get(X86::PF),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X86::AF),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X86::ZF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::SF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::TF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::IF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::DF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::OF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::IOPL),1,0), res);
+        res.set_concat(extract(ctx.get(X86::NT),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X86::RF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::VM),0,0), res);
+        res.set_concat(extract(ctx.get(X86::AC),0,0), res);
+        res.set_concat(extract(ctx.get(X86::VIF),0,0), res);
+        res.set_concat(extract(ctx.get(X86::VIP),0,0), res);
+        res.set_concat(extract(ctx.get(X86::ID),0,0), res);
+        res.set_concat(Value(10,0), res);
     }
     else
         throw runtime_exception("x86_alias_getter: got unsupported register");
@@ -97,33 +97,33 @@ void x64_alias_setter(CPUContext& ctx, ir::reg_t reg, const Value& val)
         throw runtime_exception("x64_alias_setter: got unsupported register");
 }
 
-Value x64_alias_getter(const CPUContext& ctx, ir::reg_t reg)
+Value x64_alias_getter(CPUContext& ctx, ir::reg_t reg)
 {
     Value res;
     if (reg == X64::RFLAGS)
     {
         res = extract(ctx.get(X64::CF),0,0);
-        res.set_concat(res, Value(1,1));
-        res.set_concat(res, extract(ctx.get(X64::PF),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X64::AF),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X64::ZF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::SF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::TF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::IF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::DF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::OF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::IOPL),1,0));
-        res.set_concat(res, extract(ctx.get(X64::NT),0,0));
-        res.set_concat(res, Value(1,0));
-        res.set_concat(res, extract(ctx.get(X64::RF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::VM),0,0));
-        res.set_concat(res, extract(ctx.get(X64::AC),0,0));
-        res.set_concat(res, extract(ctx.get(X64::VIF),0,0));
-        res.set_concat(res, extract(ctx.get(X64::VIP),0,0));
-        res.set_concat(res, extract(ctx.get(X64::ID),0,0));
-        res.set_concat(res, Value(42,0));
+        res.set_concat(Value(1,1), res);
+        res.set_concat(extract(ctx.get(X64::PF),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X64::AF),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X64::ZF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::SF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::TF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::IF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::DF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::OF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::IOPL),1,0), res);
+        res.set_concat(extract(ctx.get(X64::NT),0,0), res);
+        res.set_concat(Value(1,0), res);
+        res.set_concat(extract(ctx.get(X64::RF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::VM),0,0), res);
+        res.set_concat(extract(ctx.get(X64::AC),0,0), res);
+        res.set_concat(extract(ctx.get(X64::VIF),0,0), res);
+        res.set_concat(extract(ctx.get(X64::VIP),0,0), res);
+        res.set_concat(extract(ctx.get(X64::ID),0,0), res);
+        res.set_concat(Value(42,0), res);
     }
     else
         throw runtime_exception("x64_alias_getter: got unsupported register");

--- a/src/arch/register_aliases.cpp
+++ b/src/arch/register_aliases.cpp
@@ -4,9 +4,13 @@
 namespace maat{
 namespace ir{
 
-inline void _set_flag_from_bit(CPUContext& ctx, ir::reg_t reg, const Value& val, int bit, int nb_bits=1)
-__attribute__((always_inline))
-{
+inline void __attribute__((always_inline)) _set_flag_from_bit(
+    CPUContext& ctx,
+    ir::reg_t reg,
+    const Value& val,
+    int bit,
+    int nb_bits=1
+){
     ctx.set(reg, concat(Value(8-nb_bits, 0), extract(val, nb_bits-1+bit, bit)));
 }
 

--- a/src/arch/register_aliases.cpp
+++ b/src/arch/register_aliases.cpp
@@ -1,0 +1,152 @@
+#include "maat/cpu.hpp"
+#include "maat/arch.hpp"
+
+namespace maat{
+namespace ir{
+
+inline void _set_flag_from_bit(CPUContext& ctx, ir::reg_t reg, const Value& val, int bit, int nb_bits=1)
+__attribute__((always_inline))
+{
+    ctx.set(reg, concat(Value(8-nb_bits, 0), extract(val, nb_bits-1, 0)));
+}
+
+void x86_alias_setter(CPUContext& ctx, ir::reg_t reg, const Value& val)
+{
+    if (reg == X86::EFLAGS)
+    {
+        _set_flag_from_bit(ctx, X86::CF, val, 0);
+        _set_flag_from_bit(ctx, X86::PF, val, 2);
+        _set_flag_from_bit(ctx, X86::AF, val, 4);
+        _set_flag_from_bit(ctx, X86::ZF, val, 6);
+        _set_flag_from_bit(ctx, X86::SF, val, 7);
+        _set_flag_from_bit(ctx, X86::TF, val, 8);
+        _set_flag_from_bit(ctx, X86::IF, val, 9);
+        _set_flag_from_bit(ctx, X86::DF, val, 10);
+        _set_flag_from_bit(ctx, X86::OF, val, 11);
+        _set_flag_from_bit(ctx, X86::IOPL, val, 12, 2);
+        _set_flag_from_bit(ctx, X86::NT, val, 14);
+        _set_flag_from_bit(ctx, X86::RF, val, 16);
+        _set_flag_from_bit(ctx, X86::VM, val, 17);
+        _set_flag_from_bit(ctx, X86::AC, val, 18);
+        _set_flag_from_bit(ctx, X86::VIF, val, 19);
+        _set_flag_from_bit(ctx, X86::VIP, val, 20);
+        _set_flag_from_bit(ctx, X86::ID, val, 21);
+    }
+    else
+        throw runtime_exception("x86_alias_setter: got unsupported register");
+}
+
+Value x86_alias_getter(const CPUContext& ctx, ir::reg_t reg)
+{
+    Value res;
+    if (reg == X86::EFLAGS)
+    {
+        res = extract(ctx.get(X86::CF),0,0);
+        res.set_concat(res, Value(1,1));
+        res.set_concat(res, extract(ctx.get(X86::PF),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X86::AF),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X86::ZF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::SF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::TF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::IF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::DF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::OF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::IOPL),1,0));
+        res.set_concat(res, extract(ctx.get(X86::NT),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X86::RF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::VM),0,0));
+        res.set_concat(res, extract(ctx.get(X86::AC),0,0));
+        res.set_concat(res, extract(ctx.get(X86::VIF),0,0));
+        res.set_concat(res, extract(ctx.get(X86::VIP),0,0));
+        res.set_concat(res, extract(ctx.get(X86::ID),0,0));
+        res.set_concat(res, Value(10,0));
+    }
+    else
+        throw runtime_exception("x86_alias_getter: got unsupported register");
+    return res;
+}
+
+std::set x86_aliases{X86::EFLAGS};
+
+void x64_alias_setter(CPUContext& ctx, ir::reg_t reg, const Value& val)
+{
+    if (reg == X64::RFLAGS)
+    {
+        _set_flag_from_bit(ctx, X64::CF, val, 0);
+        _set_flag_from_bit(ctx, X64::PF, val, 2);
+        _set_flag_from_bit(ctx, X64::AF, val, 4);
+        _set_flag_from_bit(ctx, X64::ZF, val, 6);
+        _set_flag_from_bit(ctx, X64::SF, val, 7);
+        _set_flag_from_bit(ctx, X64::TF, val, 8);
+        _set_flag_from_bit(ctx, X64::IF, val, 9);
+        _set_flag_from_bit(ctx, X64::DF, val, 10);
+        _set_flag_from_bit(ctx, X64::OF, val, 11);
+        _set_flag_from_bit(ctx, X64::IOPL, val, 12, 2);
+        _set_flag_from_bit(ctx, X64::NT, val, 14);
+        _set_flag_from_bit(ctx, X64::RF, val, 16);
+        _set_flag_from_bit(ctx, X64::VM, val, 17);
+        _set_flag_from_bit(ctx, X64::AC, val, 18);
+        _set_flag_from_bit(ctx, X64::VIF, val, 19);
+        _set_flag_from_bit(ctx, X64::VIP, val, 20);
+        _set_flag_from_bit(ctx, X64::ID, val, 21);
+    }
+    else
+        throw runtime_exception("x64_alias_setter: got unsupported register");
+}
+
+Value x64_alias_getter(const CPUContext& ctx, ir::reg_t reg)
+{
+    Value res;
+    if (reg == X64::RFLAGS)
+    {
+        res = extract(ctx.get(X64::CF),0,0);
+        res.set_concat(res, Value(1,1));
+        res.set_concat(res, extract(ctx.get(X64::PF),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X64::AF),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X64::ZF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::SF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::TF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::IF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::DF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::OF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::IOPL),1,0));
+        res.set_concat(res, extract(ctx.get(X64::NT),0,0));
+        res.set_concat(res, Value(1,0));
+        res.set_concat(res, extract(ctx.get(X64::RF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::VM),0,0));
+        res.set_concat(res, extract(ctx.get(X64::AC),0,0));
+        res.set_concat(res, extract(ctx.get(X64::VIF),0,0));
+        res.set_concat(res, extract(ctx.get(X64::VIP),0,0));
+        res.set_concat(res, extract(ctx.get(X64::ID),0,0));
+        res.set_concat(res, Value(42,0));
+    }
+    else
+        throw runtime_exception("x64_alias_getter: got unsupported register");
+    return res;
+}
+
+std::set x64_aliases{X64::RFLAGS};
+
+void CPUContext::init_alias_getset(Arch::Type arch)
+{
+    if (arch == Arch::Type::X86)
+    {
+        alias_setter = x86_alias_setter;
+        alias_getter = x86_alias_getter;
+        aliased_regs = x86_aliases;
+    }
+    else if (arch == Arch::Type::X64)
+    {
+        alias_setter = x64_alias_setter;
+        alias_getter = x64_alias_getter;
+        aliased_regs = x64_aliases;
+    }
+}
+
+} // namespace ir
+} // namespace maat

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -46,6 +46,7 @@ MaatEngine::MaatEngine(Arch::Type _arch, env::OS os)
     callother_handlers = callother::default_handler_map();
     // Initialize all registers to their proper bit-size with value 0
     cpu = ir::CPU(arch->nb_regs);
+    cpu.ctx().init_alias_getset(arch->type);
     for (reg_t reg = 0; reg < arch->nb_regs; reg++)
         cpu.ctx().set(reg, Number(arch->reg_size(reg), 0));
     // Initialize some variables for execution statefullness
@@ -1349,6 +1350,7 @@ void MaatEngine::load(serial::Deserializer& d)
       >> snapshots >> arch >> vars >> mem
       >> cpu >> env >> symbols >> process
       >> info >> settings;
+    cpu.ctx().init_alias_getset(arch->type);
     // Lifter(s)
     size_t tmp_size;
     d >> bits(tmp_size);

--- a/src/include/maat/arch.hpp
+++ b/src/include/maat/arch.hpp
@@ -183,7 +183,8 @@ namespace X86
     static constexpr reg_t ST5 = 66;
     static constexpr reg_t ST6 = 67;
     static constexpr reg_t ST7 = 68;
-    static constexpr reg_t NB_REGS = 69;
+    static constexpr reg_t EFLAGS = 69;
+    static constexpr reg_t NB_REGS = 70;
 
     /** \addtogroup arch
      * \{ */
@@ -302,7 +303,8 @@ namespace X64
     static constexpr reg_t ST5 = 76;
     static constexpr reg_t ST6 = 77;
     static constexpr reg_t ST7 = 78;
-    static constexpr reg_t NB_REGS = 87;
+    static constexpr reg_t RFLAGS = 87;
+    static constexpr reg_t NB_REGS = 88;
 
     /** \addtogroup arch
      * \{ */

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -35,7 +35,7 @@ namespace ir
 // Register aliases setter callback
 class CPUContext;
 using reg_alias_setter_t = std::function<void(CPUContext&, ir::reg_t, const Value&)>;
-using reg_alias_getter_t = std::function<Value(const CPUContext&, ir::reg_t)>;
+using reg_alias_getter_t = std::function<Value(CPUContext&, ir::reg_t)>;
 
 /** The CPU context in Maat's IR. It is basically
  * a mapping between abstract expressions and CPU registers */
@@ -72,11 +72,13 @@ public:
     void set(ir::reg_t reg, const Number& value);
 
     /// Get current value of register *reg* as an abstract expression
-    const Value& get(ir::reg_t reg) const;
+    const Value& get(ir::reg_t reg);
 
 private:
     // Internal method that handles setting register aliases
-    void _set_aliased_reg(ir::reg_t reg, const Value& val);
+    inline void _set_aliased_reg(ir::reg_t reg, const Value& val) __attribute__((always_inline));
+    // Internal method to check if a register is an alias
+    inline bool _is_alias(ir::reg_t reg) const __attribute__((always_inline));
 
 public:
     /// Print the CPU context to a stream

--- a/src/third-party/sleigh/native/reg_translator.cpp
+++ b/src/third-party/sleigh/native/reg_translator.cpp
@@ -477,6 +477,8 @@ maat::ir::Param sleigh_reg_translate_X86(const std::string& reg_name)
     if (reg_name == "FPUDataPointer") return maat::ir::Reg(maat::X86::FPUDP, 32);
     if (reg_name == "FPULastInstructionOpcode") return maat::ir::Reg(maat::X86::FPUOP, 11);
     if (reg_name == "CR0") return maat::ir::Reg(maat::X86::CR0, 32);
+    if (reg_name == "eflags") return maat::ir::Reg(maat::X86::EFLAGS, 32);
+    if (reg_name == "flags") return maat::ir::Reg(maat::X86::EFLAGS, 16);
 
     throw maat::runtime_exception(maat::Fmt()
             << "X86: Register translation from SLEIGH to MAAT missing for register "
@@ -1291,6 +1293,10 @@ maat::ir::Param sleigh_reg_translate_X64(const std::string& reg_name)
     if (reg_name == "ST5") return maat::ir::Reg(maat::X64::ST5, 80);
     if (reg_name == "ST6") return maat::ir::Reg(maat::X64::ST6, 80);
     if (reg_name == "ST7") return maat::ir::Reg(maat::X64::ST7, 80);
+
+    if (reg_name == "rflags") return maat::ir::Reg(maat::X64::RFLAGS, 64);
+    if (reg_name == "eflags") return maat::ir::Reg(maat::X64::RFLAGS, 32);
+    if (reg_name == "flags") return maat::ir::Reg(maat::X64::RFLAGS, 16);
 
     throw maat::runtime_exception(maat::Fmt()
             << "X64: Register translation from SLEIGH to MAAT missing for register "

--- a/tests/unit-tests/test_archX64.cpp
+++ b/tests/unit-tests/test_archX64.cpp
@@ -1792,6 +1792,27 @@ namespace test{
 
             return nb;
         }
+
+        unsigned int disass_pushfq(MaatEngine& sym){
+            unsigned int nb = 0;
+            string code("\x9C", 1); // pushfd
+            sym.mem->write_buffer(0x1000, (uint8_t*)code.c_str(), code.size());
+            sym.mem->write_buffer(0x1000+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
+            sym.cpu.ctx().set(X64::RFLAGS, 13);
+            sym.cpu.ctx().set(X64::RSP, 0x1908);
+
+            sym.run_from(0x1000, 1);
+            nb += _assert(
+                sym.cpu.ctx().get(X64::RSP).as_uint() == 0x1900,
+                "ArchX64: failed to disassembly and/or execute PUSHFQ"
+            );
+            nb += _assert(
+                sym.mem->read(0x1900, 8).as_uint() == sym.cpu.ctx().get(X64::RFLAGS).as_uint(),
+                "ArchX64: failed to disassembly and/or execute PUSHFQ"
+            );
+
+            return nb;
+        }
         
         unsigned int disass_pxor(MaatEngine& engine){
             unsigned int nb = 0;
@@ -2730,6 +2751,7 @@ void test_archX64(){
     */
     total += disass_punpcklwd(engine);
     total += disass_push(engine);
+    total += disass_pushfq(engine);
     total += disass_pxor(engine);
     total += disass_rcl(engine);
     total += disass_rcr(engine);

--- a/tests/unit-tests/test_archX86.cpp
+++ b/tests/unit-tests/test_archX86.cpp
@@ -6624,7 +6624,7 @@ namespace test
                
             return nb;
         }
-        
+
         unsigned int disass_pushad(MaatEngine& sym){
             unsigned int nb = 0;
             string code;
@@ -6660,6 +6660,27 @@ namespace test
                             "ArchX86: failed to disassembly and/or execute PUSHAD");
             nb += _assert(  (uint32_t)sym.mem->read(0x1800, 4).as_uint() == 0x11111111,
                             "ArchX86: failed to disassembly and/or execute PUSHAD");
+
+            return nb;
+        }
+
+        unsigned int disass_pushfd(MaatEngine& sym){
+            unsigned int nb = 0;
+            string code("\x9C", 1); // pushfd
+            sym.mem->write_buffer(0x1000, (uint8_t*)code.c_str(), code.size());
+            sym.mem->write_buffer(0x1000+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
+            sym.cpu.ctx().set(X86::EFLAGS, 13);
+            sym.cpu.ctx().set(X86::ESP, 0x1904);
+            
+            sym.run_from(0x1000, 1);
+            nb += _assert(
+                sym.cpu.ctx().get(X86::ESP).as_uint() == 0x1900,
+                "ArchX86: failed to disassembly and/or execute PUSHFD"
+            );
+            nb += _assert(
+                sym.mem->read(0x1900, 4).as_uint() == sym.cpu.ctx().get(X86::EFLAGS).as_uint(),
+                "ArchX86: failed to disassembly and/or execute PUSHFD"
+            );
 
             return nb;
         }
@@ -9220,6 +9241,7 @@ void test_archX86(){
     total += disass_punpcklwd(engine);
     total += disass_push(engine);
     total += disass_pushad(engine);
+    total += disass_pushfd(engine);
     total += disass_pxor(engine);
 
     total += disass_rcl(engine);


### PR DESCRIPTION
This PR adds a callback mechanism that allows to define register aliases for a given architecture. It implements such aliasing for `EFLAGS` and `RFLAGS` on `X86` and `X64` respectively.

Closes #80 