### PR TITLE
Add support for compiling with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,10 @@ if(maat_USE_EXTERNAL_SLEIGH)
   find_package(sleigh REQUIRED)
 else()
   set(sleigh_ENABLE_TESTS OFF CACHE BOOL "")
+  # See: https://developercommunity.visualstudio.com/t/error-c2872-byte-ambiguous-symbol/93889
+  if(MSVC)
+    add_compile_definitions(_HAS_STD_BYTE=0)
+  endif()
   add_subdirectory(src/third-party/sleigh/sleigh-cmake sleigh EXCLUDE_FROM_ALL)
 endif()
 

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -12,6 +12,9 @@ if(PROJECT_IS_TOP_LEVEL)
   option(maat_DEVELOPER_MODE "Enable developer mode" OFF)
   option(maat_RUN_PYTHON_TESTS "Enable running the Python tests" ON)
   option(BUILD_SHARED_LIBS "Build shared libs." OFF)
+  
+  # Enable folder support
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 endif()
 
 # These variables correspond to the dependencies that maat doesn't

--- a/src/arch/register_aliases.cpp
+++ b/src/arch/register_aliases.cpp
@@ -4,7 +4,7 @@
 namespace maat{
 namespace ir{
 
-inline void __attribute__((always_inline)) _set_flag_from_bit(
+inline ALWAYS_INLINE void _set_flag_from_bit(
     CPUContext& ctx,
     ir::reg_t reg,
     const Value& val,

--- a/src/env/env_linux.cpp
+++ b/src/env/env_linux.cpp
@@ -44,16 +44,16 @@ void LinuxEmulator::add_running_process(const ProcessInfo& pinfo, const std::str
     fs.create_symlink("/proc/self/exe", pinfo.binary_path, true);
 
     // Create stdin,stdout,stderr, for this process
-    std::string stdin = fs.get_stdin_for_pid(pinfo.pid);
-    std::string stdout = fs.get_stdout_for_pid(pinfo.pid);
-    std::string stderr = fs.get_stderr_for_pid(pinfo.pid);
+    std::string stdin_ = fs.get_stdin_for_pid(pinfo.pid);
+    std::string stdout_ = fs.get_stdout_for_pid(pinfo.pid);
+    std::string stderr_ = fs.get_stderr_for_pid(pinfo.pid);
 
-    fs.create_file(stdin);
-    fs.create_file(stdout);
-    fs.create_file(stderr);
-    fs._new_fa(stdin, 0);
-    fs._new_fa(stdout, 1);
-    fs._new_fa(stderr, 2);
+    fs.create_file(stdin_);
+    fs.create_file(stdout_);
+    fs.create_file(stderr_);
+    fs._new_fa(stdin_, 0);
+    fs._new_fa(stdout_, 1);
+    fs._new_fa(stderr_, 2);
     fs.get_file_by_handle(1)->flush_stream = std::ref(std::cout);
     fs.get_file_by_handle(2)->flush_stream = std::ref(std::cerr);
 }

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -76,9 +76,9 @@ public:
 
 private:
     // Internal method that handles setting register aliases
-    inline void _set_aliased_reg(ir::reg_t reg, const Value& val) __attribute__((always_inline));
+    inline ALWAYS_INLINE void _set_aliased_reg(ir::reg_t reg, const Value& val);
     // Internal method to check if a register is an alias
-    inline bool _is_alias(ir::reg_t reg) const __attribute__((always_inline));
+    inline ALWAYS_INLINE bool _is_alias(ir::reg_t reg) const;
 
 public:
     /// Print the CPU context to a stream
@@ -147,35 +147,33 @@ private:
     /** \brief Extracts bit field (high_bit and low_bit included) from 'expr'. If
      * the extract extracts the whole expression, then simply returns 'expr'
      * without performing the extract */
-    inline Expr _extract_abstract_if_needed(Expr expr, size_t high_bit, size_t low_bit)
-    __attribute__((always_inline));
+    inline ALWAYS_INLINE Expr _extract_abstract_if_needed(Expr expr, size_t high_bit, size_t low_bit);
 
 
     /** \brief Extracts bit field (high_bit and low_bit included) from 'val'. 'val' is modified
      * **in place**. 
      * Returns a reference to 'val' */
-    inline Value _extract_value_bits(const Value& val, size_t high_bit, size_t low_bit)
-    __attribute__((always_inline));
+    inline ALWAYS_INLINE Value _extract_value_bits(const Value& val, size_t high_bit, size_t low_bit);
 
     /** \brief Get value of parameter 'param' (extract bits if needed).
      * get_full_register is set to true, the function doesn't truncate the
      * expression if the parameter is a register */
-    inline event::Action _get_param_value(
+    inline ALWAYS_INLINE event::Action _get_param_value(
         ProcessedInst::Param& dest,
         const ir::Param& param,
         MaatEngine& engine,
         bool get_full_register = false,
         bool trigger_events = true
-    ) __attribute__((always_inline));
+    );
 
     /** \brief Compute value to be assigned to the output parameter
      * for instruction 'inst' (with bit extract/concat if overwriting 
      * only a subset of the output current value). Set value to 'dest'. */
-    inline void _compute_res_value(
+    inline ALWAYS_INLINE void _compute_res_value(
         Value& dest,
         const ir::Inst& inst,
         ProcessedInst& pinst
-    ) __attribute__((always_inline));
+    );
 
 public:
     /** \brief Compute the values of the various parameters of the

--- a/src/include/maat/event.hpp
+++ b/src/include/maat/event.hpp
@@ -361,16 +361,16 @@ public:
 private:
     /// Raises a event_exception if a hook with name 'name' already exists
     void _check_unique_name(const std::string& str);
-    inline Action _trigger_hooks(
+    inline ALWAYS_INLINE Action _trigger_hooks(
         const std::vector<Event>& events,
         When when,
         MaatEngine& engine
-    ) __attribute__((always_inline));
-    inline Action _trigger_hooks(
+    );
+    inline ALWAYS_INLINE Action _trigger_hooks(
         Event event,
         When when,
         MaatEngine& engine
-    ) __attribute__((always_inline));
+    );
 public: 
     bool has_hooks(
         const std::vector<Event>& events,

--- a/src/include/maat/expression.hpp
+++ b/src/include/maat/expression.hpp
@@ -672,7 +672,7 @@ bool ite_evaluate(Expr left, ITECond cond, Expr right, const VarContext* ctx = n
  * to *higher_bit-new_expr.size()+1* with the expression 'new_expr'. **WARNING**:
  * 'new_expr' is expected to be small enough to overwrite 'old_expr' from the 
  * specified bit, no check for potential overflow is performed */
-inline Expr __attribute__((always_inline)) overwrite_expr_bits(Expr old_expr, Expr new_expr, size_t higher_bit) 
+inline Expr ALWAYS_INLINE overwrite_expr_bits(Expr old_expr, Expr new_expr, size_t higher_bit)
 {
     if (new_expr->size >= old_expr->size)
         return new_expr;

--- a/src/include/maat/serializer.hpp
+++ b/src/include/maat/serializer.hpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <functional>
 #include <memory>
+#include <optional>
 #include "maat/exception.hpp"
 
 namespace maat{

--- a/src/include/maat/types.hpp
+++ b/src/include/maat/types.hpp
@@ -2,6 +2,13 @@
 #define TYPES_H
 
 #include <stdint.h>
+#include <iso646.h>
+
+#ifdef _MSC_VER
+#define ALWAYS_INLINE __forceinline
+#else
+#define ALWAYS_INLINE __attribute__((always_inline))
+#endif // _MSC_VER
 
 /// Main namespace for Maat's API
 namespace maat

--- a/src/serialization/serialization_helpers.cpp
+++ b/src/serialization/serialization_helpers.cpp
@@ -30,7 +30,7 @@ bool SimpleStateManager::dequeue_state(MaatEngine& engine)
     if (pending_states.empty())
         return false;
 
-    std::string filename = pending_states.front();
+    std::filesystem::path filename = pending_states.front();
     pending_states.pop();
 
     std::ifstream in(filename, std::ios_base::binary);
@@ -39,7 +39,7 @@ bool SimpleStateManager::dequeue_state(MaatEngine& engine)
     in.close();
 
     if (delete_on_load)
-        remove(filename.c_str());
+        remove(filename.string().c_str());
 
     return true;
 }

--- a/src/serialization/serializer.cpp
+++ b/src/serialization/serializer.cpp
@@ -1,5 +1,6 @@
 #include "maat/serializer.hpp"
 #include "maat/exception.hpp"
+#include "maat/types.hpp"
 
 namespace maat{
 namespace serial{


### PR DESCRIPTION
Mostly a draft to see if there is interest. The changes are quite minimal, the only functional change I made was the `mulhshr` function because MSVC doesn't support `uint128_t`.

If this is something you would merge I can do CI with GitHub Actions for Windows as well.