### PR TITLE
Adding ITE overload with constraint, and created python binding

### DIFF
--- a/bindings/python/py_constraint.cpp
+++ b/bindings/python/py_constraint.cpp
@@ -88,12 +88,12 @@ PyObject* maat_ITE(PyObject* self, PyObject* args)
         return PyErr_Format(PyExc_TypeError, "Mismatching type for ITE arguments");
     }
 
-	try{
-		res = ITE(*(as_constraint_object(cond).constr), if_true_val.as_expr(), if_false_val.as_expr());
-		return PyValue_FromValue(res);
-	} catch(expression_exception e) {
-		return PyErr_Format(PyExc_ValueError, "%s", e.what());
-	}
+    try{
+        res = ITE(*(as_constraint_object(cond).constr), if_true_val.as_expr(), if_false_val.as_expr());
+	    return PyValue_FromValue(res);
+        } catch(expression_exception e) {
+            return PyErr_Format(PyExc_ValueError, "%s", e.what());
+        }
 }
 
 static PyMethodDef Constraint_methods[] = {

--- a/bindings/python/py_constraint.cpp
+++ b/bindings/python/py_constraint.cpp
@@ -67,23 +67,23 @@ PyObject* maat_ITE(PyObject* self, PyObject* args)
     }
 
     Value res;
-	Value if_true_val;
-	Value if_false_val;
-
-	// We cannot accept ITE with both if_true and if_false as constants without a size parameter
-
-	if( PyLong_Check(if_true) && PyLong_Check(if_false)) {
-		return PyErr_Format(PyExc_ValueError, "ITE requires at least one argument be a value inorder to deduce resulting size");
-	}else if( PyLong_Check(if_true) && PyObject_IsInstance(if_false, get_Value_Type())) {
-		if_false_val = *(as_value_object(if_false).value);
-		if_true_val.set_cst(if_false_val.size(), PyLong_AsLongLong(if_true));
-	}else if( PyLong_Check(if_false) && PyObject_IsInstance(if_true, get_Value_Type())) {
-		if_true_val = *(as_value_object(if_true).value);
-		if_false_val.set_cst(if_true_val.size(), PyLong_AsLongLong(if_false));
-	}else if( PyObject_IsInstance(if_true, get_Value_Type()) && PyObject_IsInstance(if_false, get_Value_Type())) {
-		// ExprITE will make sure sizes match
-		if_true_val = *(as_value_object(if_true).value);
-		if_false_val = *(as_value_object(if_false).value);
+    Value if_true_val;
+    Value if_false_val;
+    
+    // We cannot accept ITE with both if_true and if_false as constants without a size parameter
+    
+    if( PyLong_Check(if_true) && PyLong_Check(if_false)) {
+        return PyErr_Format(PyExc_ValueError, "ITE requires at least one argument be a value inorder to deduce resulting size");
+    }else if( PyLong_Check(if_true) && PyObject_IsInstance(if_false, get_Value_Type())) {
+        if_false_val = *(as_value_object(if_false).value);
+        if_true_val.set_cst(if_false_val.size(), PyLong_AsLongLong(if_true));
+    }else if( PyLong_Check(if_false) && PyObject_IsInstance(if_true, get_Value_Type())) {
+        if_true_val = *(as_value_object(if_true).value);
+        if_false_val.set_cst(if_true_val.size(), PyLong_AsLongLong(if_false));
+    }else if( PyObject_IsInstance(if_true, get_Value_Type()) && PyObject_IsInstance(if_false, get_Value_Type())) {
+        // ExprITE will make sure sizes match
+        if_true_val = *(as_value_object(if_true).value);
+        if_false_val = *(as_value_object(if_false).value);
     }else{
         return PyErr_Format(PyExc_TypeError, "Mismatching type for ITE arguments");
     }

--- a/bindings/python/py_constraint.cpp
+++ b/bindings/python/py_constraint.cpp
@@ -57,6 +57,45 @@ static PyObject* Constraint_contained_vars(PyObject* self) {
     return list;
 }
 
+PyObject* maat_ITE(PyObject* self, PyObject* args)
+{
+    Constraint_Object* cond;
+    PyObject* if_true;
+    PyObject* if_false;
+    if( ! PyArg_ParseTuple(args, "O!OO", get_Constraint_Type(), &cond, &if_true, &if_false)){
+        return NULL;
+    }
+
+    Value res;
+	Value if_true_val;
+	Value if_false_val;
+
+	// We cannot accept ITE with both if_true and if_false as constants without a size parameter
+
+	if( PyLong_Check(if_true) && PyLong_Check(if_false)) {
+		return PyErr_Format(PyExc_ValueError, "ITE requires at least one argument be a value inorder to deduce resulting size");
+	}else if( PyLong_Check(if_true) && PyObject_IsInstance(if_false, get_Value_Type())) {
+		if_false_val = *(as_value_object(if_false).value);
+		if_true_val = exprcst(if_false_val.size(), PyLong_AsLongLong(if_true));
+	}else if( PyLong_Check(if_false) && PyObject_IsInstance(if_true, get_Value_Type())) {
+		if_true_val = *(as_value_object(if_true).value);
+		if_false_val = exprcst(if_true_val.size(), PyLong_AsLongLong(if_false));
+	}else if( PyObject_IsInstance(if_true, get_Value_Type()) && PyObject_IsInstance(if_false, get_Value_Type())) {
+		// ExprITE will make sure sizes match
+		if_true_val = *(as_value_object(if_true).value);
+		if_false_val = *(as_value_object(if_false).value);
+    }else{
+        return PyErr_Format(PyExc_TypeError, "Mismatching type for ITE arguments");
+    }
+
+	try{
+		res = ITE(*(as_constraint_object(cond).constr), as_value_object(if_true).value->as_expr(), as_value_object(if_false).value->as_expr());
+		return PyValue_FromValue(res);
+	} catch(expression_exception e) {
+		return PyErr_Format(PyExc_ValueError, "%s", e.what());
+	}
+}
+
 static PyMethodDef Constraint_methods[] = {
     {"invert", (PyCFunction)Constraint_invert, METH_NOARGS, "Returns the invert of the condition"},
     {"contained_vars", (PyCFunction)Constraint_contained_vars, METH_NOARGS, "Returns a list of involved symbolic variables"},

--- a/bindings/python/py_constraint.cpp
+++ b/bindings/python/py_constraint.cpp
@@ -76,10 +76,10 @@ PyObject* maat_ITE(PyObject* self, PyObject* args)
 		return PyErr_Format(PyExc_ValueError, "ITE requires at least one argument be a value inorder to deduce resulting size");
 	}else if( PyLong_Check(if_true) && PyObject_IsInstance(if_false, get_Value_Type())) {
 		if_false_val = *(as_value_object(if_false).value);
-		if_true_val = exprcst(if_false_val.size(), PyLong_AsLongLong(if_true));
+		if_true_val.set_cst(if_false_val.size(), PyLong_AsLongLong(if_true));
 	}else if( PyLong_Check(if_false) && PyObject_IsInstance(if_true, get_Value_Type())) {
 		if_true_val = *(as_value_object(if_true).value);
-		if_false_val = exprcst(if_true_val.size(), PyLong_AsLongLong(if_false));
+		if_false_val.set_cst(if_true_val.size(), PyLong_AsLongLong(if_false));
 	}else if( PyObject_IsInstance(if_true, get_Value_Type()) && PyObject_IsInstance(if_false, get_Value_Type())) {
 		// ExprITE will make sure sizes match
 		if_true_val = *(as_value_object(if_true).value);
@@ -89,7 +89,7 @@ PyObject* maat_ITE(PyObject* self, PyObject* args)
     }
 
 	try{
-		res = ITE(*(as_constraint_object(cond).constr), as_value_object(if_true).value->as_expr(), as_value_object(if_false).value->as_expr());
+		res = ITE(*(as_constraint_object(cond).constr), if_true_val.as_expr(), if_false_val.as_expr());
 		return PyValue_FromValue(res);
 	} catch(expression_exception e) {
 		return PyErr_Format(PyExc_ValueError, "%s", e.what());

--- a/bindings/python/py_maat.cpp
+++ b/bindings/python/py_maat.cpp
@@ -16,6 +16,7 @@ PyMethodDef module_methods[] = {
     {"VarContext", (PyCFunction)maat_VarContext, METH_VARARGS, "Create a new VarContext"},
     {"Concat", (PyCFunction)maat_Concat, METH_VARARGS, "Concatenate two abstract expressions"},
     {"Extract", (PyCFunction)maat_Extract, METH_VARARGS, "Bitfield extract from an abstract expression"},
+    {"ITE", (PyCFunction)maat_ITE, METH_VARARGS, "Create an If-Then-Else expression from a Constraint and two abstract expressions"},
     // Engine
     {"MaatEngine", (PyCFunction)maat_MaatEngine, METH_VARARGS, "Create a new DSE engine"},
     // Solver

--- a/bindings/python/py_value.cpp
+++ b/bindings/python/py_value.cpp
@@ -521,7 +521,7 @@ PyObject* maat_Extract(PyObject* self, PyObject* args)
     CATCH_EXPRESSION_EXCEPTION ( return PyValue_FromValue( extract(*(as_value_object(val).value), higher, lower)); )
 }
 
-// TODO SAR, ITE, ...
+// TODO SAR, ...
 
 PyObject* PyValue_FromValue(const Value& e)
 {

--- a/bindings/python/python_bindings.hpp
+++ b/bindings/python/python_bindings.hpp
@@ -33,6 +33,7 @@ typedef struct {
 PyObject* maat_Cst(PyObject* self, PyObject* args, PyObject* keywords);
 PyObject* maat_Var(PyObject* self, PyObject* args, PyObject* keywords);
 PyObject* maat_Concat(PyObject* self, PyObject* args);
+PyObject* maat_ITE(PyObject* self, PyObject* args);
 PyObject* maat_Extract(PyObject* self, PyObject* args);
 PyObject* PyValue_FromValue(const Value& val);
 PyObject* PyValue_FromValueAndVarContext(const Value& val, std::shared_ptr<VarContext> ctx);

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -301,20 +301,20 @@ Expr ITE(Constraint cond, Expr if_true, Expr if_false)
 {
     ITECond itecond;
     bool swap = false;
-    auto& l_e = cond->left_expr;
-    auto& r_e = cond->right_expr;
+    Expr l_e = cond->left_expr;
+    Expr r_e = cond->right_expr;
 
     switch(cond->type)
     {
         case ConstraintType::AND:
             l_e = ITE(cond->left_constr, exprcst(1, 1), exprcst(1, 0)) &
-				ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
+            ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
             r_e = exprcst(1, 1);
             itecond = ITECond::EQ;
             break;
         case ConstraintType::OR:
             l_e = ITE(cond->left_constr, exprcst(1, 1), exprcst(1, 0)) |
-				ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
+            ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
             r_e = exprcst(1, 1);
             itecond = ITECond::EQ;
             break;

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -297,5 +297,56 @@ Constraint operator||(Constraint left, Constraint right)
     return std::make_shared<ConstraintObject>(ConstraintType::OR, left, right);
 }
 
+Expr ITE(Constraint cond, Expr if_true, Expr if_false)
+{
+    ITECond itecond;
+    bool swap = false;
+    auto l_e = cond->left_expr;
+    auto r_e = cond->right_expr;
+
+    switch(cond->type)
+    {
+        case ConstraintType::AND:
+            l_e = ITE(cond->left_constr, exprcst(1, 1), exprcst(1, 0)) &
+				ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
+            r_e = exprcst(1, 1);
+            itecond = ITECond::EQ;
+            break;
+        case ConstraintType::OR:
+            l_e = ITE(cond->left_constr, exprcst(1, 1), exprcst(1, 0)) |
+				ITE(cond->right_constr, exprcst(1, 1), exprcst(1, 0));
+            r_e = exprcst(1, 1);
+            itecond = ITECond::EQ;
+            break;
+        case ConstraintType::EQ:
+            itecond = ITECond::EQ;
+            break;
+        case ConstraintType::NEQ:
+            itecond = ITECond::EQ;
+            swap = true;
+            break;
+        case ConstraintType::LE:
+            itecond = ITECond::SLE;
+            break;
+        case ConstraintType::LT:
+            itecond = ITECond::SLT;
+            break;
+        case ConstraintType::ULE:
+            itecond = ITECond::LE;
+            break;
+        case ConstraintType::ULT:
+            itecond = ITECond::LT;
+            break;
+        default:
+            throw runtime_exception("ConstraintObject::invert() got unknown constraint type");
+    }
+
+	if (swap) {
+		return ITE(l_e, itecond, r_e, if_false, if_true);
+	} else {
+		return ITE(l_e, itecond, r_e, if_true, if_false);
+	}
+}
+
 
 } // namespace maat

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -301,8 +301,8 @@ Expr ITE(Constraint cond, Expr if_true, Expr if_false)
 {
     ITECond itecond;
     bool swap = false;
-    auto l_e = cond->left_expr;
-    auto r_e = cond->right_expr;
+    auto& l_e = cond->left_expr;
+    auto& r_e = cond->right_expr;
 
     switch(cond->type)
     {

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -338,7 +338,7 @@ Expr ITE(Constraint cond, Expr if_true, Expr if_false)
             itecond = ITECond::LT;
             break;
         default:
-            throw runtime_exception("ConstraintObject::invert() got unknown constraint type");
+            throw runtime_exception("ITE(): got unknown constraint type");
     }
 
 	if (swap) {

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -341,11 +341,11 @@ Expr ITE(Constraint cond, Expr if_true, Expr if_false)
             throw runtime_exception("ITE(): got unknown constraint type");
     }
 
-	if (swap) {
-		return ITE(l_e, itecond, r_e, if_false, if_true);
-	} else {
-		return ITE(l_e, itecond, r_e, if_true, if_false);
-	}
+    if (swap) {
+        return ITE(l_e, itecond, r_e, if_false, if_true);
+    } else {
+        return ITE(l_e, itecond, r_e, if_true, if_false);
+    }
 }
 
 

--- a/src/include/maat/constraint.hpp
+++ b/src/include/maat/constraint.hpp
@@ -112,6 +112,8 @@ Constraint ULT(ucst_t left, Expr right); ///< Create an unsigned less-than const
 Constraint operator&&(Constraint left, Constraint right); ///< Combine constraints (*left* AND *right*)
 Constraint operator||(Constraint left, Constraint right); ///< Combine constraints (*left* OR *right*)
 
+Expr ITE(Constraint cond, Expr if_true, Expr if_false); ///< Create new ExprITE instance from Constraint
+
 /** \} */ // End of doxygen group constraint
 
 // TODO add a .evaluate(VarContext) method...

--- a/src/include/maat/serializer.hpp
+++ b/src/include/maat/serializer.hpp
@@ -1,6 +1,7 @@
 #ifndef MAAT_SERIALIZER_HPP
 #define MAAT_SERIALIZER_HPP
 
+#include <optional>
 #include <unordered_map>
 #include <queue>
 #include <string>

--- a/tests/unit-tests/test_expression.cpp
+++ b/tests/unit-tests/test_expression.cpp
@@ -87,7 +87,7 @@ namespace test
             nb += _assert_hash_neq(e6,e7);
             nb += _assert_hash_neq(e9, e5%e3);
             nb += _assert_hash_neq(e10, ITE(e1, ITECond::EQ, e2, e7, e6));
-            nb += _assert_hash_eq(e11, ITE(c1, e7, e6));
+            nb += _assert_hash_neq(e11, ITE(c1, e7, e6));
             return nb;
         }
 

--- a/tests/unit-tests/test_expression.cpp
+++ b/tests/unit-tests/test_expression.cpp
@@ -236,9 +236,9 @@ namespace test
                     e3 = extract(v1, 8, 1),
                     e4 = concat(v2,v1),
                     e5 = ITE(v1, ITECond::LE, v2, v3, v4);
-            Constraint c1 = e1 == e2,
-                    c2 = e3 > e4,
-                    c3 = c1 && c3;
+            Constraint c1 = v1 == v2,
+                    c2 = v1 > v2,
+                    c3 = c1 || c2;
             Expr    e6 = ITE(c3, v3, v4);
             
             ctx.set("var1", 10);

--- a/tests/unit-tests/test_solver.cpp
+++ b/tests/unit-tests/test_solver.cpp
@@ -1,6 +1,7 @@
 #include "maat/expression.hpp"
 #include "maat/solver.hpp"
 #include "maat/exception.hpp"
+#include "maat/constraint.hpp"
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -30,6 +31,10 @@ namespace test
             e2 = exprvar(64, "var2");
             e3 = exprvar(64, "var3");
             e4 = exprvar(64, "var4");
+            Constraint c1, c2, c3;
+            c1 = e1 == e2;
+            c2 = e3 != e4;
+            c3 = c1 || c2;
             
             s.reset();
             s.add(e1 == e2 && e2 == e3 && e3 == e4 && e1 != e4);
@@ -75,7 +80,12 @@ namespace test
             s.add( ITE( e1, ITECond::EQ, e2, exprcst(64,42), exprcst(64,1)) ==  42);
             s.add(e1 < e3);
             s.add(e3 <= e2);
+            nb += _assert(!s.check(), "Solver: got model for unsat constraint ! ");
 
+            s.reset();
+            s.add( ITE(c3, exprcst(64,42), exprcst(64,1)) == 42);
+            s.add(e1 < e2);
+            s.add(e3 == e4);
             nb += _assert(!s.check(), "Solver: got model for unsat constraint ! ");
 
             return nb;


### PR DESCRIPTION
This pull request adds a `Expr ITE(Constraint cond, Expr if_true, Expr if_false)` function, and exposes it with a python binding.

Some things that I can change depending on what you want:

Currently the new `ITE` function is in `constraint.cpp`, while the other overload is in `expression.cpp`. Maybe it would make more sense to have them together? The reason they are apart is that currently `expression.cpp` doesn't know about the `Constraint` type and I'd have to add some forward declarations to be able to put it there.
Likewise the python binding `maat_ITE` is in `py_constraint.cpp` and could be moved to `py_value.cpp` if that makes more sense.

And the other thing, looking through the unit tests, I wasn't sure where a good fit would be. Should I add to a few tests in `test_expression.cpp` that use the new constraint form of `ITE`?