### PR TITLE
Throw exception when assign value which doesn't match register size

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -434,6 +434,7 @@ bool MaatEngine::process_branch(
             }
             else // address, branch to it
             {
+                // Trigger hooks
                 if (hooks.has_hooks(Event::BRANCH, When::BEFORE))
                 {
                     info.addr = asm_inst.addr();

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -163,12 +163,17 @@ private:
     __attribute__((always_inline));
 
     /** \brief Get value of parameter 'param' (extract bits if needed).
-     * get_full_register is set to true, the function doesn't truncate the
-     * expression if the parameter is a register */
+      
+     If get_full_register is set to true, the function doesn't truncate the
+     expression if the parameter is a register.
+     
+     If force_addr_64 is true, the function forces address constants to be
+     64-bit values */
     inline event::Action _get_param_value(
         ProcessedInst::Param& dest,
         const ir::Param& param,
         MaatEngine& engine,
+        bool force_addr_64 = true,
         bool get_full_register = false,
         bool trigger_events = true
     ) __attribute__((always_inline));

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -165,15 +165,11 @@ private:
     /** \brief Get value of parameter 'param' (extract bits if needed).
       
      If get_full_register is set to true, the function doesn't truncate the
-     expression if the parameter is a register.
-     
-     If force_addr_64 is true, the function forces address constants to be
-     64-bit values */
+     expression if the parameter is a register. */
     inline event::Action _get_param_value(
         ProcessedInst::Param& dest,
         const ir::Param& param,
         MaatEngine& engine,
-        bool force_addr_64 = true,
         bool get_full_register = false,
         bool trigger_events = true
     ) __attribute__((always_inline));

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -42,8 +42,6 @@ using reg_alias_getter_t = std::function<Value(CPUContext&, ir::reg_t)>;
 class CPUContext: public serial::Serializable
 {
 private:
-    std::shared_ptr<Arch> _arch;
-private:
     std::vector<Value> regs;
 private:
     reg_alias_getter_t alias_getter;

--- a/src/include/maat/cpu.hpp
+++ b/src/include/maat/cpu.hpp
@@ -42,6 +42,8 @@ using reg_alias_getter_t = std::function<Value(CPUContext&, ir::reg_t)>;
 class CPUContext: public serial::Serializable
 {
 private:
+    std::shared_ptr<Arch> _arch;
+private:
     std::vector<Value> regs;
 private:
     reg_alias_getter_t alias_getter;
@@ -79,7 +81,10 @@ private:
     inline void _set_aliased_reg(ir::reg_t reg, const Value& val) __attribute__((always_inline));
     // Internal method to check if a register is an alias
     inline bool _is_alias(ir::reg_t reg) const __attribute__((always_inline));
-
+    // Check that new value assignment matches the current size of the register
+    // Throws cpu_exception on a wrong assignment size, and std::out_of_range
+    // if 'reg_idx' is invalid 
+    void _check_assignment_size(int reg_idx, size_t size) const;
 public:
     /// Print the CPU context to a stream
     friend std::ostream& operator<<(std::ostream& os, const CPUContext& ctx);

--- a/src/include/maat/exception.hpp
+++ b/src/include/maat/exception.hpp
@@ -94,7 +94,7 @@ public:
 class loader_exception: public generic_exception {
 public:
     explicit loader_exception(std::string msg): generic_exception(msg){};
-}; 
+};
 
 /** Event exception */
 class event_exception: public generic_exception {
@@ -106,6 +106,11 @@ public:
 class ir_exception: public generic_exception {
 public:
     explicit ir_exception(std::string msg): generic_exception(msg){};
+};
+
+class cpu_exception: public generic_exception {
+public:
+    explicit cpu_exception(std::string msg): generic_exception(msg){};
 };
 
 /** Symbolic engine exception */

--- a/src/ir/cpu.cpp
+++ b/src/ir/cpu.cpp
@@ -374,7 +374,6 @@ event::Action CPU::_get_param_value(
     ProcessedInst::Param& dest,
     const ir::Param& param,
     MaatEngine& engine,
-    bool force_addr_64,
     bool get_full_register,
     bool trigger_events
 )
@@ -399,10 +398,7 @@ event::Action CPU::_get_param_value(
         // refer to the number of bits accessed, not the size of the address!
         // So address is size 64, and the engine will handle how many bits
         // to read or write later...
-        if (force_addr_64)
-            dest.set_cst(64, param.addr());
-        else
-            dest.set_cst(param.size(), param.addr());
+        dest.set_cst(64, param.addr());
     }
     else if (param.is_tmp())
     {
@@ -623,14 +619,10 @@ ProcessedInst& CPU::pre_process_inst(
 )
 {
     processed_inst.reset();
-    bool force_addr_64 = (
-        inst.op != ir::Op::BRANCH and
-        inst.op != ir::Op::CBRANCH and
-        inst.op != ir::Op::CALL
-    );
+
     // TODO: use Value& at least for input values....
-    _get_param_value(processed_inst.out, inst.out, engine, false, true, false);
-    event::merge_actions(action, _get_param_value(processed_inst.in0, inst.in[0], engine, force_addr_64));
+    _get_param_value(processed_inst.out, inst.out, engine, true, false);
+    event::merge_actions(action, _get_param_value(processed_inst.in0, inst.in[0], engine));
     event::merge_actions(action, _get_param_value(processed_inst.in1, inst.in[1], engine));
     event::merge_actions(action, _get_param_value(processed_inst.in2, inst.in[2], engine));
     return processed_inst;

--- a/src/ir/cpu.cpp
+++ b/src/ir/cpu.cpp
@@ -193,13 +193,14 @@ void CPUContext::set(ir::reg_t reg, const Value& value)
     int idx(reg);
     try
     {
+        _check_assignment_size(idx, value.size());
         regs.at(idx) = value;
     }
     catch(const std::out_of_range&)
     {
         throw ir_exception(Fmt()
                 << "CPUContext: Trying to set register " << std::dec << idx
-                << " which doesn't exist in current context"
+                << " which doesn't exist in current context" >> Fmt::to_str
             );
     }
     _set_aliased_reg(reg, value);
@@ -210,6 +211,7 @@ void CPUContext::set(ir::reg_t reg, Expr value)
     int idx(reg);
     try
     {
+        _check_assignment_size(idx, value->size);
         regs.at(idx) = value;
     }
     catch(const std::out_of_range&)
@@ -244,6 +246,7 @@ void CPUContext::set(ir::reg_t reg, Number&& value)
     int idx(reg);
     try
     {
+        _check_assignment_size(idx, value.size);
         regs.at(idx) = value;
     }
     catch(const std::out_of_range&)
@@ -261,6 +264,7 @@ void CPUContext::set(ir::reg_t reg, const Number& value)
     int idx(reg);
     try
     {
+        _check_assignment_size(idx, value.size);
         regs.at(idx) = value;
     }
     catch(const std::out_of_range&)
@@ -271,6 +275,16 @@ void CPUContext::set(ir::reg_t reg, const Number& value)
             );
     }
     _set_aliased_reg(reg, value);
+}
+
+void CPUContext::_check_assignment_size(int idx, size_t size) const
+{
+    if (not regs.at(idx).is_none() and regs.at(idx).size() != size)
+        throw cpu_exception( Fmt()
+            << "Can't assign " << std::dec << size << "-bits value to "
+            << regs.at(idx).size() << "-bits register" << "\n" 
+            >> Fmt::to_str
+        );
 }
 
 bool CPUContext::_is_alias(ir::reg_t reg) const

--- a/src/ir/cpu.cpp
+++ b/src/ir/cpu.cpp
@@ -175,11 +175,9 @@ void ProcessedInst::reset()
     in2.set_none();
 }
 
-
 CPUContext::CPUContext(int nb_regs): alias_setter(nullptr), alias_getter(nullptr)
 {
     regs = std::vector<Value>(nb_regs);
-    
 }
 
 void CPUContext::_set_aliased_reg(ir::reg_t reg, const Value& val)

--- a/src/ir/cpu.cpp
+++ b/src/ir/cpu.cpp
@@ -374,6 +374,7 @@ event::Action CPU::_get_param_value(
     ProcessedInst::Param& dest,
     const ir::Param& param,
     MaatEngine& engine,
+    bool force_addr_64,
     bool get_full_register,
     bool trigger_events
 )
@@ -398,7 +399,10 @@ event::Action CPU::_get_param_value(
         // refer to the number of bits accessed, not the size of the address!
         // So address is size 64, and the engine will handle how many bits
         // to read or write later...
-        dest.set_cst(64, param.addr());
+        if (force_addr_64)
+            dest.set_cst(64, param.addr());
+        else
+            dest.set_cst(param.size(), param.addr());
     }
     else if (param.is_tmp())
     {
@@ -618,12 +622,15 @@ ProcessedInst& CPU::pre_process_inst(
     MaatEngine& engine
 )
 {
-
     processed_inst.reset();
-
+    bool force_addr_64 = (
+        inst.op != ir::Op::BRANCH and
+        inst.op != ir::Op::CBRANCH and
+        inst.op != ir::Op::CALL
+    );
     // TODO: use Value& at least for input values....
-    _get_param_value(processed_inst.out, inst.out, engine, true, false);
-    event::merge_actions(action, _get_param_value(processed_inst.in0, inst.in[0], engine));
+    _get_param_value(processed_inst.out, inst.out, engine, false, true, false);
+    event::merge_actions(action, _get_param_value(processed_inst.in0, inst.in[0], engine, force_addr_64));
     event::merge_actions(action, _get_param_value(processed_inst.in1, inst.in[1], engine));
     event::merge_actions(action, _get_param_value(processed_inst.in2, inst.in[2], engine));
     return processed_inst;

--- a/tests/unit-tests/test_archX64.cpp
+++ b/tests/unit-tests/test_archX64.cpp
@@ -239,7 +239,7 @@ namespace test{
             
             // bsf 0x10000
             engine.cpu.ctx().set(X64::RBX, exprcst(64,0x10000));
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::ZF).as_uint(*engine.vars) == 1,
                             "ArchX64: failed to disassembly and/or execute BSF");
@@ -423,7 +423,7 @@ namespace test{
             // bit(0x8, 3)
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x8));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,3));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint(*engine.vars) == exprcst(64, 1)->as_uint(*engine.vars),
                             "ArchX64: failed to disassembly and/or execute BT");
@@ -450,7 +450,7 @@ namespace test{
             engine.mem->write(0x1700, exprcst(32, 0xffffffff));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x1701));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,8));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint(*engine.vars) == 1,
                             "ArchX64: failed to disassembly and/or execute BT");
@@ -462,7 +462,7 @@ namespace test{
             // bit(0x10000000, 28)
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x10000000));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,28));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint(*engine.vars) == 1,
                             "ArchX64: failed to disassembly and/or execute BT");
@@ -509,7 +509,7 @@ namespace test{
             // bit(0x100000001234, 44)
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x100000001234));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,44));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1210, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint(*engine.vars) == 1,
                             "ArchX64: failed to disassembly and/or execute BT");
@@ -808,7 +808,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(8, 0xff));
             engine.mem->write(0x1500, exprcst(8, 0xf));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -829,7 +829,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(8, 0x1));
             engine.mem->write(0x1500, exprcst(8, 0xff));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -861,7 +861,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(64, 0xAAAA));
             engine.mem->write(0x1500, exprcst(64, 0xAAAA));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -882,7 +882,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(64, 0x1234));
             engine.mem->write(0x1500, exprcst(64, 0x1235));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -914,7 +914,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(16, 0xAAAA000011110001));
             engine.mem->write(0x1500, exprcst(16, 0xAAAA000011110000));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -935,7 +935,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(64, 0x1000000000001234));
             engine.mem->write(0x1500, exprcst(64, 0x1000000000001235));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -967,7 +967,7 @@ namespace test{
             
             engine.mem->write(0x1000, exprcst(16, 0xAAAA));
             engine.mem->write(0x1500, exprcst(16, 0xAAAA));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -988,7 +988,7 @@ namespace test{
 
             engine.mem->write(0x1000, exprcst(64, 0x1234));
             engine.mem->write(0x1500, exprcst(64, 0x1235));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RSI, exprcst(64,0x1000));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -1220,7 +1220,7 @@ namespace test{
             engine.mem->write_buffer(0x1170, (uint8_t*)code.c_str(), code.size());
             engine.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123400000021));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0x20)->as_uint(),
@@ -1240,7 +1240,7 @@ namespace test{
             
             
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x1111ffffff01));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0xffffff00)->as_uint(),
@@ -1263,7 +1263,7 @@ namespace test{
             engine.mem->write_buffer(0x1180, (uint8_t*)code.c_str(), code.size());
             engine.mem->write_buffer(0x1180+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123400000022));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0x123400000021)->as_uint(),
@@ -1439,7 +1439,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,48));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 4));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RDX, exprcst(64, 0x11001234));
             engine.run_from(0x1010, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xC0, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1456,7 +1456,7 @@ namespace test{
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x1230000000000+ 4823424));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, -423));
             engine.cpu.ctx().set(X64::RDX, exprcst(64, 0x11001234));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1020, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x86635d80, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == -423, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1472,7 +1472,7 @@ namespace test{
             engine.cpu.ctx().set(X64::RAX, exprcst(64,-2));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0x3300000000));
             engine.cpu.ctx().set(X64::RDX, exprcst(64, 0x11001234));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x2020, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == -0x6600000000, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 0x3300000000, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1487,7 +1487,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123410000002)); // 2 * -2 
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0x1000fffe));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1030, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x12341000fffc, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 0x1000fffe, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1501,7 +1501,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x2));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0x80000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1040, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x00000002, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1514,7 +1514,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x200000000)); // 0x200000000 * -2 
             engine.cpu.ctx().set(X64::RBX, exprcst(64, -0x2));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x2040, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == -0x400000000, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1528,7 +1528,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xaaaa12345678));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0x00100000));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1050, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x00700000, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 0x00100000, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1538,7 +1538,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x12345678));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0xffffffff));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1050, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xfffffff9, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 0xffffffff, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1552,7 +1552,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xaaaa12345678));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 17));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1060, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10000000, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 17, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1562,7 +1562,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123412345678));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, -1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1060, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf0000000, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == -1, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1576,7 +1576,7 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xaaaa12345678));
             engine.cpu.ctx().set(X64::RBX, exprcst(64, 0x33000000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x2060, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x99000000003, "ArchX64: failed to disassembly and/or execute IMUL");
             nb += _assert(  engine.cpu.ctx().get(X64::RBX).as_uint() == 0x33000000001, "ArchX64: failed to disassembly and/or execute IMUL");
@@ -1594,7 +1594,7 @@ namespace test{
             engine.mem->write_buffer(0x1170, (uint8_t*)code.c_str(), 2);
             engine.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123400000022));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0x23)->as_uint(),
@@ -1610,7 +1610,7 @@ namespace test{
             nb += _assert(  engine.cpu.ctx().get(X64::SF).as_uint() == 0,
                             "ArchX64: failed to disassembly and/or execute INC");
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xaa00ffffff01));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0xffffff02)->as_uint(),
@@ -1630,7 +1630,7 @@ namespace test{
             engine.mem->write_buffer(0x1180, (uint8_t*)code.c_str(), code.size());
             engine.mem->write_buffer(0x1180+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x123400000022));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == exprcst(64, 0x123400000023)->as_uint(),
@@ -1659,26 +1659,26 @@ namespace test{
             engine.mem->write_buffer(0x1002+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             /* Taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x1012, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x1000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x1002, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x1000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x1002, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x1000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x1002, "ArchX64: failed to disassembly and/or execute JA");
 
@@ -1689,26 +1689,26 @@ namespace test{
             engine.mem->write_buffer(0x2006, (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             /* Taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x2000, 1);
             nb += _assert( engine.cpu.ctx().get(X64::RIP).as_uint() == 0x125456, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0));
             engine.run_from(0x2000, 1);
             nb += _assert( engine.cpu.ctx().get(X64::RIP).as_uint() == 0x2006, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x2000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x2006, "ArchX64: failed to disassembly and/or execute JA");
             
             /* Not taken */
-            engine.cpu.ctx().set(X64::ZF, exprcst(64,1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::ZF, exprcst(8,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x2000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RIP).as_uint() == 0x2006, "ArchX64: failed to disassembly and/or execute JA");
             
@@ -1848,15 +1848,15 @@ namespace test{
             engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1234000010201));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x12340000100c0, "ArchX64: failed to disassembly and/or execute RCL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCL");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10010));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10800, "ArchX64: failed to disassembly and/or execute RCL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCL");
@@ -1867,8 +1867,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x44444445, "ArchX64: failed to disassembly and/or execute RCL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCL");
@@ -1876,8 +1876,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x80000000));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCL");
@@ -1890,21 +1890,21 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x3f));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xc000000000000000, "ArchX64: failed to disassembly and/or execute RCL");
             // Sleigh error on 64 bits in ia.sinc, they have a typo (zero missing in final 0x1000000000.....) nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCL");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x4000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert( engine.cpu.ctx().get(X64::RAX).as_uint() == 0x8000000000000003, "ArchX64: failed to disassembly and/or execute RCL");
             // Sleigh bug  nb += _assert( engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCL");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x12345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x12345678deadbeef, "ArchX64: failed to disassembly and/or execute RCL");
             // Sleigh bug  nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCL");
@@ -1922,15 +1922,15 @@ namespace test{
             engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x11200));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10224, "ArchX64: failed to disassembly and/or execute RCR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCR");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x11240));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10024, "ArchX64: failed to disassembly and/or execute RCR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCR");
@@ -1941,8 +1941,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x91111111, "ArchX64: failed to disassembly and/or execute RCR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCR");
@@ -1950,8 +1950,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x10000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x08000000, "ArchX64: failed to disassembly and/or execute RCR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCR");
@@ -1964,21 +1964,21 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000000));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x3f));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x3, "ArchX64: failed to disassembly and/or execute RCR");
             // Sleigh bug, see RCL nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute RCR");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x4000000000000000, "ArchX64: failed to disassembly and/or execute RCR");
             // Sleigh bug nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCR");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf2345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf2345678deadbeef, "ArchX64: failed to disassembly and/or execute RCR");
             // Sleigh bug  nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute RCR");
@@ -2027,13 +2027,13 @@ namespace test{
             engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10201));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10081, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute ROL");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10010));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10800, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROL");
@@ -2044,8 +2044,8 @@ namespace test{
                
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x44444444, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROL");
@@ -2053,8 +2053,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x80000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 3, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute ROL");
@@ -2066,8 +2066,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x123400001111));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x123400000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1190, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x2222, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROL");
@@ -2080,21 +2080,21 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000000));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x3f));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x4000000000000000, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROL");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x3, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute ROL");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf2345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf2345678deadbeef, "ArchX64: failed to disassembly and/or execute ROL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROL");
@@ -2111,13 +2111,13 @@ namespace test{
             engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10201));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10204, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10018));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x13000, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
@@ -2128,8 +2128,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x11111111, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
@@ -2137,8 +2137,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x80000000));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x40000000, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
@@ -2150,8 +2150,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x123400001111));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x123400000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1190, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x80000888, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute ROR");
@@ -2164,21 +2164,21 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000000));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x3f));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x1, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x8000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xc000000000000000, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute ROR");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf2345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf2345678deadbeef, "ArchX64: failed to disassembly and/or execute ROR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute ROR");
@@ -2241,13 +2241,13 @@ namespace test{
             
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10201));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x12010, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAL");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x11010));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10100, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2258,8 +2258,8 @@ namespace test{
                
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x44444444, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2267,8 +2267,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x80000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 2, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2279,8 +2279,8 @@ namespace test{
             engine.mem->write_buffer(0x1190+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1234dead00000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1190, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x1000, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2293,8 +2293,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf000000000000000));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x2));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xc000000000000000, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2302,8 +2302,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xc000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x8000000000000002, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2311,8 +2311,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf2345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 0));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf2345678deadbeef, "ArchX64: failed to disassembly and/or execute SAL");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAL");
@@ -2330,13 +2330,13 @@ namespace test{
             engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x10201));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10020, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAR");
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1f008));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
             engine.run_from(0x1160, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x1ff00, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAR");
@@ -2347,8 +2347,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x22222222));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0x11111111, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAR");
@@ -2356,8 +2356,8 @@ namespace test{
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0x1700));
             engine.mem->write(0x1700, exprcst(64, 0x80000001));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.mem->read(0x1700, 4).as_uint() == 0xc0000000, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAR");
@@ -2370,15 +2370,15 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf000000000000000));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x2));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xfc00000000000000, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAR");
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xc000000000000001));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x1));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xe000000000000000, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 1, "ArchX64: failed to disassembly and/or execute SAR");
@@ -2386,8 +2386,8 @@ namespace test{
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64, 0xf2345678deadbeef));
             engine.cpu.ctx().set(X64::RCX, exprcst(64, 0x0));
-            engine.cpu.ctx().set(X64::CF, exprcst(64, 0));
-            engine.cpu.ctx().set(X64::OF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8, 0));
+            engine.cpu.ctx().set(X64::OF, exprcst(8, 1));
             engine.run_from(0x1180, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf2345678deadbeef, "ArchX64: failed to disassembly and/or execute SAR");
             nb += _assert(  engine.cpu.ctx().get(X64::CF).as_uint() == 0, "ArchX64: failed to disassembly and/or execute SAR");
@@ -2406,7 +2406,7 @@ namespace test{
             engine.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xff));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,0x1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,0x1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xf0,
                             "ArchX64: failed to disassembly and/or execute SBB");
@@ -2424,7 +2424,7 @@ namespace test{
                             "ArchX64: failed to disassembly and/or execute SBB");
                             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x10ff));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x1170, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x10f0,
                             "ArchX64: failed to disassembly and/or execute SBB");
@@ -2446,7 +2446,7 @@ namespace test{
             engine.mem->write_buffer(0x1190+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x80));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x1190, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0xff,
                             "ArchX64: failed to disassembly and/or execute SBB");
@@ -2467,7 +2467,7 @@ namespace test{
             engine.mem->write_buffer(0x1000+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x1ffff));
-            engine.cpu.ctx().set(X64::CF, exprcst(64,1));
+            engine.cpu.ctx().set(X64::CF, exprcst(8,1));
             engine.run_from(0x1000, 1);
             nb += _assert(  engine.cpu.ctx().get(X64::RAX).as_uint() == 0x1ff00,
                             "ArchX64: failed to disassembly and/or execute SBB");
@@ -2494,7 +2494,7 @@ namespace test{
             engine.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.mem->write(0x1500, exprcst(8, 0xf));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 1));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 1));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0xff));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);
@@ -2512,7 +2512,7 @@ namespace test{
                             "ArchX64: failed to disassembly and/or execute SCASB");
             
             engine.mem->write(0x1500, exprcst(8, 0xff));
-            engine.cpu.ctx().set(X64::DF, exprcst(64, 0));
+            engine.cpu.ctx().set(X64::DF, exprcst(8, 0));
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x1));
             engine.cpu.ctx().set(X64::RDI, exprcst(64,0x1500));
             engine.run_from(0x1170, 1);

--- a/tests/unit-tests/test_archX86.cpp
+++ b/tests/unit-tests/test_archX86.cpp
@@ -96,7 +96,7 @@ namespace test
             
             /* Test with AF set */
             // AL = 7
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 1)); // Set carry flag
+            sym.cpu.ctx().set(X86::AF, exprcst(8, 1)); // Set carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x7));
             sym.run_from(0x1000, 1);
 
@@ -108,7 +108,7 @@ namespace test
             nb += _assert(  sym.cpu.ctx().get(X86::AF).as_uint() == 1,
                             "ArchX86: failed to disassembly and/or execute AAA");
             // AL = 7 
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 1)); // Set carry flag
+            sym.cpu.ctx().set(X86::AF, exprcst(8, 1)); // Set carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b1101));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 0b100000011)->as_uint(),
@@ -119,7 +119,7 @@ namespace test
                             "ArchX86: failed to disassembly and/or execute AAA");
                             
             // AL = 3 
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 1)); // Set carry flag
+            sym.cpu.ctx().set(X86::AF, exprcst(8, 1)); // Set carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b0011));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 0b100001001)->as_uint(),
@@ -131,7 +131,7 @@ namespace test
             
              /* Test when the 4 LSB are > 9 and AF not set*/
             // AL = 10 
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 0)); // Clear carry flag
+            sym.cpu.ctx().set(X86::AF, 0); // Clear carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b1010));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 0b100000000)->as_uint(),
@@ -141,7 +141,7 @@ namespace test
             nb += _assert(  sym.cpu.ctx().get(X86::AF).as_uint() == 1,
                             "ArchX86: failed to disassembly and/or execute AAA");
             // AL = 15 
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 0)); // Clear carry flag
+            sym.cpu.ctx().set(X86::AF, 0); // Clear carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b1111));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 0b100000101)->as_uint(),
@@ -153,7 +153,7 @@ namespace test
             
              /* Test when the 4 LSB are <= 9 and AF not set*/
             // AL = 0b11110000
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 0)); // Clear carry flag
+            sym.cpu.ctx().set(X86::AF, 0); // Clear carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b11110000));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0,
@@ -163,7 +163,7 @@ namespace test
             nb += _assert(  sym.cpu.ctx().get(X86::AF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute AAA");
             // AL = 0x59
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 0)); // Clear carry flag
+            sym.cpu.ctx().set(X86::AF, 0); // Clear carry flag
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x59));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 0x09)->as_uint(),
@@ -1411,19 +1411,19 @@ namespace test
             sym.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 4);
             sym.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             // bsr 0x1100
-            sym.cpu.ctx().set(X86::EBX, exprcst(16,0x00001100));
+            sym.cpu.ctx().set(X86::EBX, exprcst(32,0x00001100));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 12)->as_uint(),
                             "ArchX86: failed to disassembly and/or execute BSR");
             nb += _assert(  sym.cpu.ctx().get(X86::ZF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute BSR");
             // bsr 0x0
-            sym.cpu.ctx().set(X86::EBX, exprcst(16,0x0));
+            sym.cpu.ctx().set(X86::EBX, exprcst(32,0x0));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::ZF).as_uint() == 1,
                             "ArchX86: failed to disassembly and/or execute BSR");
             // bsr 0x8000
-            sym.cpu.ctx().set(X86::EBX, exprcst(16,0x8000));
+            sym.cpu.ctx().set(X86::EBX, exprcst(32,0x8000));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == exprcst(32, 15)->as_uint(),
                             "ArchX86: failed to disassembly and/or execute BSR");
@@ -1431,7 +1431,7 @@ namespace test
                             "ArchX86: failed to disassembly and/or execute BSR");
             
             // bsr 0x10000
-            sym.cpu.ctx().set(X86::EBX, exprcst(16,0x10000));
+            sym.cpu.ctx().set(X86::EBX, exprcst(32,0x10000));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::ZF).as_uint() == 1,
                             "ArchX86: failed to disassembly and/or execute BSR");
@@ -2186,12 +2186,12 @@ namespace test
             sym.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 1);
             sym.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            sym.cpu.ctx().set(X86::DF, exprcst(32,0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8,0x1));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::DF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute CLD");
                             
-            sym.cpu.ctx().set(X86::DF, exprcst(32,0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8,0x0));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::DF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute CLD");
@@ -2206,12 +2206,12 @@ namespace test
             sym.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 1);
             sym.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
-            sym.cpu.ctx().set(X86::IF, exprcst(32,0x1));
+            sym.cpu.ctx().set(X86::IF, exprcst(8,0x1));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::IF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute CLI");
-                            
-            sym.cpu.ctx().set(X86::IF, exprcst(32,0x0));
+ 
+            sym.cpu.ctx().set(X86::IF, exprcst(8,0x0));
             sym.run_from(0x1160, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::IF).as_uint() == 0,
                             "ArchX86: failed to disassembly and/or execute CLI");
@@ -3333,7 +3333,7 @@ namespace test
 
             sym.mem->write(0x1000, exprcst(8, 0xff));
             sym.mem->write(0x1500, exprcst(8, 0xf));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -3358,7 +3358,7 @@ namespace test
 
             sym.mem->write(0x1000, exprcst(8, 0x1));
             sym.mem->write(0x1500, exprcst(8, 0xff));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -3393,7 +3393,7 @@ namespace test
             
             sym.mem->write(0x1000, exprcst(32, 0xAAAA));
             sym.mem->write(0x1500, exprcst(32, 0xAAAA));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -3414,7 +3414,7 @@ namespace test
             
             sym.mem->write(0x1000, exprcst(32, 0x1234));
             sym.mem->write(0x1500, exprcst(32, 0x1235));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -3447,7 +3447,7 @@ namespace test
             
             sym.mem->write(0x1000, exprcst(16, 0xAAAA));
             sym.mem->write(0x1500, exprcst(16, 0xAAAA));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -3468,7 +3468,7 @@ namespace test
             
             sym.mem->write(0x1000, exprcst(32, 0x1234));
             sym.mem->write(0x1500, exprcst(32, 0x1235));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::ESI, exprcst(32,0x1000));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -4806,7 +4806,7 @@ namespace test
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0));
             sym.cpu.ctx().set(X86::SF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::ZF, exprcst(8, 1));
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::AF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::PF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::CF, exprcst(8, 1));
             sym.run_from(0x1000, 1);
@@ -4815,7 +4815,7 @@ namespace test
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0b0010101000000000));
             sym.cpu.ctx().set(X86::SF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::ZF, exprcst(8, 1));
-            sym.cpu.ctx().set(X86::AF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::AF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::PF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::CF, exprcst(8, 1));
             sym.run_from(0x1000, 1);
@@ -4882,14 +4882,14 @@ namespace test
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x1234));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x12AA, "ArchX86: failed to disassembly and/or execute LODSB");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1801, "ArchX86: failed to disassembly and/or execute LODSB");
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x1234));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x12AA, "ArchX86: failed to disassembly and/or execute LODSB");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17ff, "ArchX86: failed to disassembly and/or execute LODSB");
@@ -4911,14 +4911,14 @@ namespace test
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x2));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x12345678, "ArchX86: failed to disassembly and/or execute LODSD");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1804, "ArchX86: failed to disassembly and/or execute LODSD");
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x12345678, "ArchX86: failed to disassembly and/or execute LODSD");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17fc, "ArchX86: failed to disassembly and/or execute LODSD");
@@ -4940,14 +4940,14 @@ namespace test
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 42));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x1234, "ArchX86: failed to disassembly and/or execute LODSW");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1802, "ArchX86: failed to disassembly and/or execute LODSW");
             
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x10000));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EAX).as_uint() == 0x11234, "ArchX86: failed to disassembly and/or execute LODSW");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17fe, "ArchX86: failed to disassembly and/or execute LODSW");
@@ -5252,7 +5252,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(8, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18ff, "ArchX86: failed to disassembly and/or execute MOVSB");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17ff, "ArchX86: failed to disassembly and/or execute MOVSB");
@@ -5262,7 +5262,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(16, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1901, "ArchX86: failed to disassembly and/or execute MOVSB");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1801, "ArchX86: failed to disassembly and/or execute MOVSB");
@@ -5283,7 +5283,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(32, 0xAAAAAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18fc, "ArchX86: failed to disassembly and/or execute MOVSD");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17fc, "ArchX86: failed to disassembly and/or execute MOVSD");
@@ -5293,7 +5293,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(32, 0xAAAAAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1904, "ArchX86: failed to disassembly and/or execute MOVSD");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1804, "ArchX86: failed to disassembly and/or execute MOVSD");
@@ -5338,7 +5338,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(16, 0xAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18fe, "ArchX86: failed to disassembly and/or execute MOVSW");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x17fe, "ArchX86: failed to disassembly and/or execute MOVSW");
@@ -5348,7 +5348,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(16, 0xAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::ESI, exprcst(32, 0x1800));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1902, "ArchX86: failed to disassembly and/or execute MOVSW");
             nb += _assert(  sym.cpu.ctx().get(X86::ESI).as_uint() == 0x1802, "ArchX86: failed to disassembly and/or execute MOVSW");
@@ -7132,7 +7132,7 @@ namespace test
             sym.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             sym.mem->write(0x1500, exprcst(8, 0xf));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0xff));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -7154,7 +7154,7 @@ namespace test
             */
 
             sym.mem->write(0x1500, exprcst(8, 0xff));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0x1));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -7187,7 +7187,7 @@ namespace test
             sym.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             sym.mem->write(0x1500, exprcst(32, 0xAAAA));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0xAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -7208,7 +7208,7 @@ namespace test
                             "ArchX86: failed to disassembly and/or execute SCASD");
             */
             sym.mem->write(0x1500, exprcst(32, 0x1235));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0x1234));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -7240,7 +7240,7 @@ namespace test
             sym.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             sym.mem->write(0x1500, exprcst(16, 0xAAAA));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 1));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0xAAAA));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -7262,7 +7262,7 @@ namespace test
             */
 
             sym.mem->write(0x1500, exprcst(32, 0x1235));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0));
             sym.cpu.ctx().set(X86::EAX, exprcst(32,0x1234));
             sym.cpu.ctx().set(X86::EDI, exprcst(32,0x1500));
             sym.run_from(0x1170, 1);
@@ -8130,7 +8130,7 @@ namespace test
             
             
             
-            sym.cpu.ctx().set(X86::DF, exprcst(32,0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8,0));
 
             code = string("\xfd", 1); // stc
             sym.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 1);
@@ -8149,7 +8149,7 @@ namespace test
             
             
             
-            sym.cpu.ctx().set(X86::IF, exprcst(32,0));
+            sym.cpu.ctx().set(X86::IF, exprcst(8,0));
 
             code = string("\xfb", 1); // sti
             sym.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 1);
@@ -8175,7 +8175,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(8, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18ff, "ArchX86: failed to disassembly and/or execute STOSB");
             nb += _assert(  sym.mem->read(0x1900, 1).as_uint() == 0x12, "ArchX86: failed to disassembly and/or execute STOSB");
@@ -8183,7 +8183,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(16, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1901, "ArchX86: failed to disassembly and/or execute STOSB");
             nb += _assert(  sym.mem->read(0x1900, 1).as_uint() == 0x12, "ArchX86: failed to disassembly and/or execute STOSB");
@@ -8205,7 +8205,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(32, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12345678));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18fc, "ArchX86: failed to disassembly and/or execute STOSD");
             nb += _assert(  sym.mem->read(0x1900, 4).as_uint() == 0x12345678, "ArchX86: failed to disassembly and/or execute STOSD");
@@ -8213,7 +8213,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(32, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12345678));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1904, "ArchX86: failed to disassembly and/or execute STOSD");
             nb += _assert(  sym.mem->read(0x1900, 4).as_uint() == 0x12345678, "ArchX86: failed to disassembly and/or execute STOSD");
@@ -8232,7 +8232,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(16, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12345678));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x1));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x1));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x18fe, "ArchX86: failed to disassembly and/or execute STOSW");
             nb += _assert(  sym.mem->read(0x1900, 2).as_uint() == 0x5678, "ArchX86: failed to disassembly and/or execute STOSW");
@@ -8240,7 +8240,7 @@ namespace test
             sym.mem->write(0x1900, exprcst(32, 0x23));
             sym.cpu.ctx().set(X86::EDI, exprcst(32, 0x1900));
             sym.cpu.ctx().set(X86::EAX, exprcst(32, 0x12345678));
-            sym.cpu.ctx().set(X86::DF, exprcst(32, 0x0));
+            sym.cpu.ctx().set(X86::DF, exprcst(8, 0x0));
             sym.run_from(0x1000, 1);
             nb += _assert(  sym.cpu.ctx().get(X86::EDI).as_uint() == 0x1902, "ArchX86: failed to disassembly and/or execute STOSW");
             nb += _assert(  sym.mem->read(0x1900, 2).as_uint() == 0x5678, "ArchX86: failed to disassembly and/or execute STOSW");

--- a/tests/unit-tests/test_snapshot.cpp
+++ b/tests/unit-tests/test_snapshot.cpp
@@ -29,7 +29,8 @@ namespace test
         {
             Expr    e1 = exprvar(32, "var0"),
                     e2 = exprvar(64, "var1"),
-                    c1 = exprcst(64, 0x12345678c0c0babe);
+                    c1 = exprcst(64, 0x12345678c0c0babe),
+                    c2 = exprcst(32, 0x46581fa);
             MaatEngine engine = MaatEngine(Arch::Type::NONE);
             MaatEngine::snapshot_t s1, s2;
             unsigned int nb = 0;
@@ -38,7 +39,7 @@ namespace test
             // Init 
             engine.vars->set("var0", 0x41414141);
             engine.cpu.ctx().set(0, e1);
-            engine.cpu.ctx().set(1, e2);
+            engine.cpu.ctx().set(1, e1+43);
             engine.mem->map(0x2000, 0x2fff);
             engine.mem->write(0x21b4, e2);
             
@@ -62,7 +63,7 @@ namespace test
     
             engine.mem->write(0x2204, c1);
             engine.cpu.ctx().set(0, e1+e1);
-            engine.cpu.ctx().set(1,e2+c1);
+            engine.cpu.ctx().set(1,e1+c2);
             s2 = engine.take_snapshot();
             
             engine.cpu.ctx().set(0, e1*e1);
@@ -72,11 +73,11 @@ namespace test
             nb += _assert(engine.mem->read(0x2204, 8).as_expr()->eq(c1), "SnapshotManager: rewind failed for two consecutive snapshots");
             nb += _assert(engine.mem->read(0x2200, 8).as_expr()->eq(exprcst(64, 0xc0c0babec0c0babe)), "SnapshotManager: rewind failed for two consecutive snapshots");
             nb += _assert(engine.cpu.ctx().get(0).as_expr()->eq( e1+e1), "SnapshotManager: rewind failed for two consecutive snapshots");
-            nb += _assert(engine.cpu.ctx().get(1).as_expr()->eq(c1+e2), "SnapshotManager: rewind failed for two consecutive snapshots");
+            nb += _assert(engine.cpu.ctx().get(1).as_expr()->eq(c2+e1), "SnapshotManager: rewind failed for two consecutive snapshots");
             
             engine.restore_snapshot(s1, true);
             nb += _assert(engine.cpu.ctx().get(0).as_expr()->eq(e1), "SnapshotManager: rewind failed for two consecutive snapshots");
-            nb += _assert(engine.cpu.ctx().get(1).as_expr()->eq(e2), "SnapshotManager: rewind failed for two consecutive snapshots");
+            nb += _assert(engine.cpu.ctx().get(1).as_expr()->eq(e1+43), "SnapshotManager: rewind failed for two consecutive snapshots");
             nb += _assert(engine.mem->read(0x2200, 8).as_expr()->eq(c1), "SnapshotManager: rewind failed for two consecutive snapshots");
 
             // Rewind on mixed symbolic and concrete engine.memory writes


### PR DESCRIPTION
Fixes #106. Correctly throws: 

>  \>>> m.cpu.eax = Var(34,"lala")
> 
> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
> AttributeError: Error setting attribute eax: Can't assign 34-bits value to 32-bits register