### PR TITLE
Better handling of sleigh errors

### DIFF
--- a/src/arch/lifter.cpp
+++ b/src/arch/lifter.cpp
@@ -68,6 +68,7 @@ Lifter::Lifter(CPUMode m): mode(m)
 }
 
 bool Lifter::lift_block(
+    maat::Logger& logger,
     ir::IRMap& ir_map,
     uintptr_t addr,
     code_t code,
@@ -76,8 +77,7 @@ bool Lifter::lift_block(
     bool* is_symbolic,
     bool* is_tainted,
     bool check_mappings
-)
-{
+){
     // TODO: check memory mappings
     try
     {
@@ -93,8 +93,10 @@ bool Lifter::lift_block(
     }
     catch(std::exception& e)
     {
-        // TODO: log error properly (need ref to Logger)
-        std::cout << "FATAL: Error in sleigh translate(): " << e.what() << std::endl;
+        logger.fatal(
+            "Sleigh failed to decode instructions in basic block starting at 0x",
+            std::hex, addr, ". Raised the following error: \"", e.what(), "\""
+        );
         return false;
     }
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -957,6 +957,7 @@ const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr)
         // TODO: check if code region is symbolic
         if (
             not lifters[_current_cpu_mode]->lift_block(
+                log,
                 ir_map,
                 addr,
                 mem->raw_mem_at(addr),

--- a/src/include/maat/lifter.hpp
+++ b/src/include/maat/lifter.hpp
@@ -10,6 +10,7 @@
 #include "maat/sleigh_interface.hpp"
 #include "maat/arch.hpp"
 #include "maat/serializer.hpp"
+#include "maat/logger.hpp"
 
 namespace maat
 {
@@ -47,6 +48,7 @@ public:
      *  @returns True on success and false on failure
      */
     virtual bool lift_block(
+        maat::Logger& logger,
         ir::IRMap& ir_map,
         uintptr_t addr,
         code_t code,


### PR DESCRIPTION
Improves the error message logged on a sleigh error. In particular it gives the address of the basic block sleigh failed to decode/lift. 

See #109 