### PR TITLE
Map real files into the virtual filesystem

### DIFF
--- a/bindings/python/py_filesystem.cpp
+++ b/bindings/python/py_filesystem.cpp
@@ -135,7 +135,33 @@ static PyObject* FileSystem_get_stdin_for_pid(PyObject* self, PyObject *args)
     }
 };
 
+static PyObject* FileSystem_add_real_file(PyObject* self, PyObject*args)
+{
+    const char* real_file_path;
+    const char* virtual_file_path;
+    int create_path = 1; // True by default
+
+    if( !PyArg_ParseTuple(args, "ss|p", &real_file_path, &virtual_file_path, &create_path))
+    {
+        return NULL;
+    }
+    try
+    {
+        bool res = as_fs_object(self).fs->add_real_file(
+            std::string(real_file_path),
+            std::string(virtual_file_path),
+            (bool)create_path
+        );
+        return PyBool_FromLong((int)res);
+    }
+    catch (const env_exception& e)
+    {
+        return PyErr_Format(PyExc_RuntimeError, "%s", e.what());
+    }
+}
+
 static PyMethodDef FileSystem_methods[] = {
+    {"add_real_file", (PyCFunction)FileSystem_add_real_file, METH_VARARGS, "Map a real file in the virtual file system"},
     {"new_fa", (PyCFunction)FileSystem_new_fa, METH_VARARGS, "Create a new file accessor for a file"},
     {"get_fa_by_handle", (PyCFunction)FileSystem_get_fa_by_handle, METH_VARARGS, "Get a file accessor by handle"},
     {"delete_fa", (PyCFunction)FileSystem_delete_fa, METH_VARARGS | METH_KEYWORDS, "Remove a file accessor"},

--- a/src/env/env_linux.cpp
+++ b/src/env/env_linux.cpp
@@ -32,9 +32,7 @@ void LinuxEmulator::_init(Arch::Type arch)
 void LinuxEmulator::add_running_process(const ProcessInfo& pinfo, const std::string& filepath)
 {
     // Create actual file
-    fs.create_file(pinfo.binary_path, true); // create_path = true
-    physical_file_t file = fs.get_file(pinfo.binary_path);
-    file->copy_real_file(filepath);
+    fs.add_real_file(filepath, pinfo.binary_path, true);
 
     // Set symbolic links to loaded binary in /proc/<pid>/exe
     // and /proc/self/exe

--- a/src/env/filesystem.cpp
+++ b/src/env/filesystem.cpp
@@ -797,6 +797,23 @@ bool FileSystem::create_file(const std::string& path, bool create_path)
     return true;
 }
 
+bool FileSystem::add_real_file(
+    const std::string& real_file_path,
+    const std::string& virtual_file_path,
+    bool create_path
+){
+    if (not create_file(virtual_file_path, create_path))
+        return false;
+
+    env::physical_file_t pfile = get_file(virtual_file_path);
+    if (pfile == nullptr) {
+        throw env_exception(
+            "FileSystem::add_real_file(): unexpected internal error while getting virtual file"
+        );
+    }
+    pfile->copy_real_file(real_file_path);
+}
+
 physical_file_t FileSystem::get_file(const std::string& path, bool follow_symlink)
 {
     Directory& dir = (path[0] == orphan_file_wildcard) ? orphan_files : root;

--- a/src/env/filesystem.cpp
+++ b/src/env/filesystem.cpp
@@ -812,6 +812,7 @@ bool FileSystem::add_real_file(
         );
     }
     pfile->copy_real_file(real_file_path);
+    return true;
 }
 
 physical_file_t FileSystem::get_file(const std::string& path, bool follow_symlink)

--- a/src/include/maat/env/filesystem.hpp
+++ b/src/include/maat/env/filesystem.hpp
@@ -50,6 +50,19 @@ public:
      * @param path Absolute path of the file
      * @param create_path If set to 'true', any missing directories in 'link' will be automatically created */
     bool create_file(const std::string& path, bool create_path=false);
+    /** \brief Create a file and initialize its content from a real file on
+    * the host system that runs Maat. 
+    * Returns 'true' on success and 'false' on failure.
+    * @param real_file_path Path to the real file on the host system
+    * @param virtual_file_path Full path where to create the virtual file in
+    * the symbolic filesystem
+    * @param create_path If set to 'false', any missing directory in 'virtual_file_path'
+    * will result in a failure */
+    bool add_real_file(
+        const std::string& real_file_path,
+        const std::string& virtual_file_path,
+        bool create_path=true
+    );
     /** \brief Delete a file
      * Returns 'true' on success and 'false' on failure
      * @param path Absolute path of the file

--- a/src/loader/loader_lief_elf.cpp
+++ b/src/loader/loader_lief_elf.cpp
@@ -599,18 +599,7 @@ void LoaderLIEF::add_elf_dependencies_to_emulated_fs(
 
         const std::string lib_fs_path =
             get_path_in_virtual_fs(engine, virtual_fs, lib_name, "/usr/lib/");
-        const env::fspath_t virtual_path =
-            engine->env->fs.fspath_from_path(lib_fs_path);
-        engine->env->fs.create_file(lib_fs_path, true);
-        env::physical_file_t pfile = engine->env->fs.get_file(lib_fs_path);
-        if (pfile == nullptr) {
-            throw loader_exception(
-                Fmt() << "Error getting file in emulated filesystem: "
-                        << lib_fs_path >>
-                Fmt::to_str);
-        }
-        addr_t offset = 0;
-        pfile->copy_real_file(lib_path);
+        engine->env->fs.add_real_file(lib_path, lib_fs_path, true);
     }
 }
 


### PR DESCRIPTION
Adds the `FileSystem::add_real_file()` method which allows to copy real files from the host system into Maat's virtual symbolic filesystem. The method is also available from python bindings:
```
m = MaatEngine(ARCH.X86, OS.LINUX)
m.env.fs.add_real_file("/some/file.txt", "/virtual/symbolic/file.txt")
```

Closes #115, related to #93 cc @integeruser 