### PR TITLE
Fix PMINUB handler

### DIFF
--- a/src/engine/callother.cpp
+++ b/src/engine/callother.cpp
@@ -85,7 +85,7 @@ void X86_PMINUB_handler(MaatEngine& engine, const ir::Inst& inst, ir::ProcessedI
             concat(extract(src2, i+7, i), res)
         );
     }
-    pinst.res = res;
+    pinst.res.set_overwrite(pinst.out.value(), res, inst.out.lb);
 }
 
 void X86_CPUID_handler(MaatEngine& engine, const ir::Inst& inst, ir::ProcessedInst& pinst)

--- a/tests/unit-tests/test_archX86.cpp
+++ b/tests/unit-tests/test_archX86.cpp
@@ -9222,7 +9222,7 @@ void test_archX86(){
     total += disass_pcmpeqd(engine);
     total += disass_pcmpgtd(engine);
     // total += disass_pextrb(engine);
-    // total += disass_pminub(engine);
+    total += disass_pminub(engine);
     // total += disass_pmovmskb(engine);
     total += disass_pop(engine);
     total += disass_popad(engine);


### PR DESCRIPTION
Fixes #112 and re-enables unit-tests for `PMINUB`