### PR TITLE
Better handling of lifting errors

### DIFF
--- a/bindings/python/py_engine.cpp
+++ b/bindings/python/py_engine.cpp
@@ -274,12 +274,48 @@ static PyObject* MaatEngine_load(PyObject* self, PyObject* args, PyObject* keywo
 };
 
 
+static PyObject* MaatEngine_get_inst_asm(PyObject* self, PyObject* args){
+    unsigned long long addr;
+    
+    if( ! PyArg_ParseTuple(args, "K", &addr) ){
+        return NULL;
+    }
+    try
+    { 
+        const std::string& res = as_engine_object(self).engine->get_inst_asm(addr);
+        return PyUnicode_FromString(res.c_str());
+    }
+    catch(const std::exception& e)
+    {
+        return PyErr_Format(PyExc_RuntimeError, "%s", e.what());
+    }
+};
+
+static PyObject* MaatEngine_get_inst_bytes(PyObject* self, PyObject* args){
+    unsigned long long addr;
+    
+    if( ! PyArg_ParseTuple(args, "K", &addr) ){
+        return NULL;
+    }
+    try
+    { 
+        std::vector<uint8_t> res = as_engine_object(self).engine->get_inst_bytes(addr);
+        return PyBytes_FromStringAndSize((char*)res.data(), res.size());
+    }
+    catch(const std::exception& e)
+    {
+        return PyErr_Format(PyExc_RuntimeError, "%s", e.what());
+    }
+};
+
 static PyMethodDef MaatEngine_methods[] = {
     {"run", (PyCFunction)MaatEngine_run, METH_VARARGS, "Continue to run code from current location"},
     {"run_from", (PyCFunction)MaatEngine_run_from, METH_VARARGS, "Run code from a given address"},
     {"take_snapshot", (PyCFunction)MaatEngine_take_snapshot, METH_NOARGS, "Take a snapshot of the symbolic engine"},
     {"restore_snapshot", (PyCFunction)MaatEngine_restore_snapshot, METH_VARARGS | METH_KEYWORDS, "Restore a snapshot of the symbolic engine"},
     {"load", (PyCFunction)MaatEngine_load, METH_VARARGS | METH_KEYWORDS, "Load an executable"},
+    {"get_inst_asm", (PyCFunction)MaatEngine_get_inst_asm, METH_VARARGS, "Get assembly code of an instruction"},
+    {"get_inst_bytes", (PyCFunction)MaatEngine_get_inst_bytes, METH_VARARGS, "Get raw bytes of an instruction"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/src/arch/lifter.cpp
+++ b/src/arch/lifter.cpp
@@ -93,7 +93,7 @@ bool Lifter::lift_block(
     }
     catch(std::exception& e)
     {
-        logger.fatal(
+        logger.error(
             "Sleigh failed to decode instructions in basic block starting at 0x",
             std::hex, addr, ". Raised the following error: \"", e.what(), "\""
         );

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -240,6 +240,18 @@ info::Stop MaatEngine::run(int max_inst)
             //      log.debug("Run IR: ", inst);
             // std::cout << "DEBUG " << inst << std::endl;
 
+            // Check for unsupported instruction
+            if (inst.op == ir::Op::UNSUPPORTED)
+            {
+                info.stop = info::Stop::UNSUPPORTED_INST;
+                info.addr = asm_inst->addr();
+                log.fatal(
+                    "Could not lift instruction at 0x", std::hex, asm_inst->addr(),
+                    ": ", get_inst_asm(asm_inst->addr())
+                );
+                return info.stop;
+            }
+
             // Pre-process IR instruction
             event::Action tmp_action = event::Action::CONTINUE;
             info.addr = asm_inst->addr();

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -983,7 +983,7 @@ const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr, unsigned int max_inst)
                 true
             )
         ){
-            throw lifter_exception("MaatEngine::run(): failed to lift instructions");
+            throw lifter_exception("MaatEngine::get_asm_inst(): failed to lift instructions");
         }
         return ir_map.get_inst_at(addr);
     }
@@ -995,7 +995,7 @@ const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr, unsigned int max_inst)
     }
     catch(const lifter_exception& e)
     {
-        log.fatal("Lifter error: ", e.what());
+        log.error("Lifter error: ", e.what());
         this->info.stop = info::Stop::FATAL;
         throw lifter_exception("MaatEngine::get_asm_inst(): lifter error");
     }
@@ -1317,6 +1317,16 @@ int MaatEngine::nb_snapshots()
 const std::string& MaatEngine::get_inst_asm(addr_t addr)
 {
     return lifters[_current_cpu_mode]->get_inst_asm(addr, mem->raw_mem_at(addr));
+}
+
+std::vector<uint8_t> MaatEngine::get_inst_bytes(addr_t addr)
+{
+    const ir::AsmInst& inst = get_asm_inst(addr);
+    std::vector<uint8_t> res((size_t)inst.raw_size());
+    uint8_t* raw_bytes = mem->raw_mem_at(addr);
+    for (int i = 0; i < inst.raw_size(); i++)
+        res[i] = raw_bytes[i];
+    return res;
 }
 
 void MaatEngine::load(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -125,17 +125,22 @@ info::Stop MaatEngine::run(int max_inst)
         }
 
         // Get next instruction to execute
-        if (current_ir_state.has_value())
-        {
-            to_execute = current_ir_state->addr;
-            ir_inst_id = current_ir_state->inst_id;
-        }
-        else if (not cpu.ctx().get(arch->pc()).is_symbolic(*vars))
+        if (not cpu.ctx().get(arch->pc()).is_symbolic(*vars))
         {
             to_execute = cpu.ctx().get(arch->pc()).as_uint(*vars);
-            ir_inst_id = 0;
-            // Reset temporaries in CPU for new instruction
-            cpu.reset_temporaries();
+            // Reload pending IR state if it matches current PC
+            if (
+                current_ir_state.has_value() and
+                current_ir_state->addr == to_execute
+            ){
+                ir_inst_id = current_ir_state->inst_id;
+            }
+            else
+            {
+                ir_inst_id = 0;
+                // Reset temporaries in CPU for new instruction
+                cpu.reset_temporaries();
+            }
         }
         else
         {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -942,7 +942,7 @@ int _get_distance_till_end_of_map(MemEngine& mem, addr_t addr)
     return res;
 }
 
-const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr)
+const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr, unsigned int max_inst)
 {
     ir::IRMap& ir_map = ir::get_ir_map(mem->uid());
     if (ir_map.contains_inst_at(addr))
@@ -951,8 +951,11 @@ const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr)
     // The code hasn't been lifted yet so we disassemble it
     try
     {
-        // Get the size of mapped code from the requested address
-        size_t code_size = _get_distance_till_end_of_map(*mem, addr);
+        // Number of instructions to lift is the max number of instructions
+        // to execute, or 'until end of basic block' (0xffffffff) if
+        // max_inst == 0
+        unsigned int code_size = (unsigned int)_get_distance_till_end_of_map(*mem, addr);
+        unsigned int max_inst_to_lift = max_inst == 0? 0xffffffff : max_inst;
 
         // TODO: check if code region is symbolic
         if (
@@ -962,7 +965,7 @@ const ir::AsmInst& MaatEngine::get_asm_inst(addr_t addr)
                 addr,
                 mem->raw_mem_at(addr),
                 code_size,
-                0xffffffff,
+                max_inst_to_lift,
                 nullptr, // is_symbolic
                 nullptr, // is_tainted
                 true

--- a/src/include/maat/engine.hpp
+++ b/src/include/maat/engine.hpp
@@ -222,8 +222,12 @@ private:
     bool process_callback_emulated_function(addr_t addr);
 private:
     /** \brief Get the AsmInst at address 'addr', lift to PCODE if needed.
-     * If an error occurs, sets info.stop and raises lifter_exception */
-    const ir::AsmInst& get_asm_inst(addr_t addr);
+     * If an error occurs, sets info.stop and raises lifter_exception
+     * @param addr Address of the instruction to get
+     * @param max_inst Maximum number of instructions to lift in the 
+     * basic block, starting at 'addr'
+     * */
+    const ir::AsmInst& get_asm_inst(addr_t addr, unsigned int max_inst=1);
 private:
     /** \brief Removes the instructions whose memory content has been tampered
      * by user callbacks or user scripts, and thus whose lift is no longer valid */

--- a/src/include/maat/engine.hpp
+++ b/src/include/maat/engine.hpp
@@ -161,6 +161,8 @@ public:
 public:
     /** \brief Return the assembly string for instruction at address 'addr' */ 
     const std::string& get_inst_asm(addr_t addr);
+    /** \brief Return the raw bytes of the instructions at address 'addr' */
+    std::vector<uint8_t> get_inst_bytes(addr_t addr);
 private:
     /** \brief Treat 'addr' as an Address parameter, load the actual value located
      * in memory and store it back in 'addr'. The previous address value stored in

--- a/src/include/maat/ir.hpp
+++ b/src/include/maat/ir.hpp
@@ -99,6 +99,7 @@ enum class Op : uint8_t
         INSERT,        
         EXTRACT,        
         POPCOUNT,
+        UNSUPPORTED,
         NONE
 };
 

--- a/src/ir/instruction.cpp
+++ b/src/ir/instruction.cpp
@@ -115,7 +115,8 @@ std::ostream& operator<<(std::ostream& os, const ir::Op& op)
         case ir::Op::NEW: os << "NEW"; break;              
         case ir::Op::INSERT: os << "INSERT"; break;          
         case ir::Op::EXTRACT: os << "EXTRACT"; break;          
-        case ir::Op::POPCOUNT: os << "POPCOUNT"; break;  
+        case ir::Op::POPCOUNT: os << "POPCOUNT"; break;
+        case ir::Op::UNSUPPORTED: os << "UNSUPPORTED"; break;
         default: os << "???"; break;
     }
     return os;

--- a/src/third-party/sleigh/native/sleigh_interface.cpp
+++ b/src/third-party/sleigh/native/sleigh_interface.cpp
@@ -363,7 +363,8 @@ public:
             return asm_cache.get_asm(address);
 
         // Get asm
-        m_loader.setData(address, bytes, 100); // TODO, 100 is arbitrary here
+        // 16 bytes is the max instruction length supported by sleigh
+        m_loader.setData(address, bytes, 16); 
         Address addr(m_sleigh->getDefaultCodeSpace(), address);
         m_sleigh->printAssembly(asm_cache, addr);
 
@@ -444,12 +445,7 @@ public:
 
                         if (id == callother::Id::UNSUPPORTED)
                         {
-                            throw maat::lifter_exception(
-                                maat::Fmt() << "Can not lift instruction at 0x"
-                                << std::hex << tmp_addr << ": " << tmp_cacher.get_asm(tmp_addr)
-                                << " (unsupported callother occurence)"
-                                >> maat::Fmt::to_str
-                            );
+                            inst = ir::Inst(ir::Op::UNSUPPORTED);
                         }
                     }
 

--- a/tests/unit-tests/test_archX64.cpp
+++ b/tests/unit-tests/test_archX64.cpp
@@ -1368,7 +1368,6 @@ namespace test{
             /* On 16 bits */
             code = string("\x66\xF7\xFB", 3); // idiv bx
             engine.mem->write_buffer(0x1170, (uint8_t*)code.c_str(), 3);
-			engine.mem->write_buffer(0x1170+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
             
             engine.cpu.ctx().set(X64::RAX, exprcst(64,-21));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,0x4));
@@ -1378,7 +1377,7 @@ namespace test{
                             "ArchX64: failed to disassembly and/or execute IDIV");
             nb += _assert(  engine.cpu.ctx().get(X64::RDX).as_uint() == exprcst(64, 0x10000003)->as_uint(),
                             "ArchX64: failed to disassembly and/or execute IDIV");
-                            
+
             engine.cpu.ctx().set(X64::RAX, exprcst(64,-24));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,0x67));
             engine.cpu.ctx().set(X64::RDX, exprcst(64,0x10000000));

--- a/tests/unit-tests/test_archX64.cpp
+++ b/tests/unit-tests/test_archX64.cpp
@@ -1356,8 +1356,8 @@ namespace test{
             /* On 8 bits */
             code = string("\xF6\xFB", 2); // idiv bl
             engine.mem->write_buffer(0x1160, (uint8_t*)code.c_str(), 2);
-            engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
-            
+            engine.mem->write_buffer(0x1160+code.size(), (uint8_t*)string("\xfe\xff\xff", 3).c_str(), 2);
+
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x10000015));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,-4));
             engine.run_from(0x1160, 1);
@@ -1391,7 +1391,6 @@ namespace test{
             /* On 64 bits */
             code = string("\x48\xf7\xfb", 3); // idiv rbx
             engine.mem->write_buffer(0x1180, (uint8_t*)code.c_str(), 3);
-			engine.mem->write_buffer(0x1180+code.size(), (uint8_t*)string("\xeb\x0e", 2).c_str(), 2);
 
             engine.cpu.ctx().set(X64::RAX, exprcst(64,0x4400000001));
             engine.cpu.ctx().set(X64::RBX, exprcst(64,-2));


### PR DESCRIPTION
This PR improves the way we lift instructions and deal with unsupported instructions:

- don't lift more instructions than what we intend to execute
- raise `UNSUPPORTED_INST` error only when trying to execute an unsupported instruction, not when lifting it

Trying to execute an unsupported instruction now results in Maat to terminate with `info.stop == STOP.UNSUPPORTED_INST`. It also exposes the `MaatEngine.get_inst_asm(<addr>)` and `MaatEngine.get_inst_bytes(<addr>)` methods to allow users to handle unsupported instructions by themselves if they wish to. 

Closes #104 