### PR TITLE
Support for reading arbitrary-sized values from memory 

### DIFF
--- a/src/include/maat/memory.hpp
+++ b/src/include/maat/memory.hpp
@@ -118,7 +118,10 @@ public:
     void extend_before(offset_t nb_bytes);
 
 public:
+    /// Read nb_bytes starting at 'off'. 'nb_bytes' must be less or equal to 8
     uint64_t read(offset_t off, int nb_bytes);
+    /// Similar to read() but can read an arbitrary number of bytes
+    Value read_as_value(offset_t off, int nb_bytes);
     /// Write the value 'val' on 'nb_bytes' starting from offset 'off'
     void write(offset_t off, int64_t val, int nb_bytes);
     /// Write the value 'val' on 'nb_bytes' starting from offset 'off'

--- a/tests/unit-tests/test_memory.cpp
+++ b/tests/unit-tests/test_memory.cpp
@@ -262,8 +262,9 @@ namespace test{
             Expr big = exprcst(128, "12345678abcdabcd0000000022223333");
             mem.write(0x1100, big, ctx);
             _assert_bignum_eq(mem.read(0x1100, 16), "0x12345678abcdabcd0000000022223333", "MemSegment failed to read then write big number"); 
+            mem.write(0x1110, c6, ctx);
+            _assert_bignum_eq(mem.read(0x1100, 20), "0xfeedbeef12345678abcdabcd0000000022223333", "MemSegment failed to read then write big number");
 
-            
             return nb;
         }
         


### PR DESCRIPTION
This PR removes the previous limitations of reading no more than 16 bytes at a time from memory. This limitation was mainly due to legacy code from before we were supporting bit-vectors of arbitrary size.

Closes #121 

**Note**: big endian support must be added when merging the `dev-evm` branch