### PR TITLE
Allow to skip the data parameter in python event callbacks

### DIFF
--- a/src/engine/event.cpp
+++ b/src/engine/event.cpp
@@ -59,6 +59,7 @@ EventCallback::EventCallback():
 {
 #ifdef MAAT_PYTHON_BINDINGS
     python_cb = nullptr;
+    python_cb_data = nullptr;
 #endif
 }
 
@@ -159,17 +160,16 @@ Action EventCallback::execute(MaatEngine& engine) const
         Action res = Action::CONTINUE;
 #ifdef MAAT_PYTHON_BINDINGS
             // Build args list
-            PyObject* cb_data = nullptr;
-            if (python_cb_data == nullptr)
-                cb_data = Py_None;
-            else
-                cb_data = python_cb_data;
+            PyObject* argslist = nullptr;
             // Note: PyTuple_Pack does increment the ref count on objects
-            PyObject* argslist = PyTuple_Pack(2, engine.self_python_wrapper_object, cb_data);
+            if (python_cb_data == nullptr)
+                argslist = PyTuple_Pack(1, engine.self_python_wrapper_object);
+            else
+                argslist = PyTuple_Pack(2, engine.self_python_wrapper_object, python_cb_data);
+
             if( argslist == NULL )
-            {
                 throw runtime_exception("EventCallback::execute(): failed to create args tuple for python callback");
-            }
+
             Py_INCREF(argslist);
             PyObject* result = PyObject_CallObject(python_cb, argslist);
             Py_DECREF(argslist);

--- a/tests/python-tests/test_linux_x64.py
+++ b/tests/python-tests/test_linux_x64.py
@@ -33,6 +33,8 @@ def test_crackme1():
     )
     stdin.write_buffer(buf)
 
+    # NOTE: data argument is unnecessary but we use it to test
+    # callback data in python 
     def solve_chall(m: MaatEngine, data):
         if m.info.addr != 0x040008b1:
             return
@@ -43,7 +45,7 @@ def test_crackme1():
             m.vars.update_from(model)
         return ACTION.HALT
 
-    m.hooks.add(EVENT.PATH, WHEN.BEFORE, callbacks=[solve_chall])
+    m.hooks.add(EVENT.PATH, WHEN.BEFORE, callbacks=[solve_chall], data=None)
     m.run()
 
     assert m.vars.get_as_str("input") == b'1bHt56z0'

--- a/tests/python-tests/test_linux_x86.py
+++ b/tests/python-tests/test_linux_x86.py
@@ -16,7 +16,7 @@ def test_crackme_vm():
     m.load(f"{X86_ELF_DIR}/crackme_vm", BIN.ELF32, load_interp=False)
 
     snapshot_next = True
-    def path_cb(m: MaatEngine, data):
+    def path_cb(m: MaatEngine):
         nonlocal snapshot_next
         if snapshot_next:
             m.take_snapshot()
@@ -45,7 +45,7 @@ def test_crackme_vm():
     m.hooks.add(EVENT.EXEC, WHEN.BEFORE, name="fail", filter=0x8048411)
 
     # Scanf hook
-    def scanf(m: MaatEngine, data):
+    def scanf(m: MaatEngine):
         _input = b"aaaaaaaaaaaapcod3s_aaaaaaaa"
         m.mem.write(0x8049a98, _input)
         m.mem.make_concolic(0x8049a98, len(_input), 1, "input")
@@ -71,7 +71,7 @@ def test_crackme_vm_serialization():
     """
     state_manager = SimpleStateManager(".")
     snapshot_next = True
-    def path_cb(m: MaatEngine, data):
+    def path_cb(m: MaatEngine):
         nonlocal snapshot_next
         nonlocal state_manager
         if snapshot_next:
@@ -107,7 +107,7 @@ def test_crackme_vm_serialization():
             snapshot_next = False
 
     # Scanf hook
-    def scanf(m: MaatEngine, data):
+    def scanf(m: MaatEngine):
         _input = b"aaaaaaaaaaaapcod3s_aaaaaaaa"
         m.mem.write(0x8049a98, _input)
         m.mem.make_concolic(0x8049a98, len(_input), 1, "input")


### PR DESCRIPTION
Fixes #130 

