### PR TITLE
Expose `ULE` and `ULT` to bindings

### DIFF
--- a/bindings/python/py_maat.cpp
+++ b/bindings/python/py_maat.cpp
@@ -17,6 +17,8 @@ PyMethodDef module_methods[] = {
     {"Concat", (PyCFunction)maat_Concat, METH_VARARGS, "Concatenate two abstract expressions"},
     {"Extract", (PyCFunction)maat_Extract, METH_VARARGS, "Bitfield extract from an abstract expression"},
     {"Sext", (PyCFunction)maat_Sext, METH_VARARGS, "Sign-extend an abstract value"},
+    {"ULE", (PyCFunction)maat_ULE, METH_VARARGS, "Unsigned less-equal constraint on abstract values"},
+    {"ULT", (PyCFunction)maat_ULT, METH_VARARGS, "Unsigned less-than constraint on abstract values"},
     {"Zext", (PyCFunction)maat_Zext, METH_VARARGS, "Zero-extend an abstract value"},
     {"ITE", (PyCFunction)maat_ITE, METH_VARARGS, "Create an If-Then-Else expression from a Constraint and two abstract expressions"},
     // Engine

--- a/bindings/python/python_bindings.hpp
+++ b/bindings/python/python_bindings.hpp
@@ -38,6 +38,8 @@ PyObject* maat_Concat(PyObject* self, PyObject* args);
 PyObject* maat_ITE(PyObject* self, PyObject* args);
 PyObject* maat_Extract(PyObject* self, PyObject* args);
 PyObject* maat_Sext(PyObject* self, PyObject* args);
+PyObject* maat_ULE(PyObject* self, PyObject* args);
+PyObject* maat_ULT(PyObject* self, PyObject* args);
 PyObject* maat_Zext(PyObject* self, PyObject* args);
 PyObject* PyValue_FromValue(const Value& val);
 PyObject* PyValue_FromValueAndVarContext(const Value& val, std::shared_ptr<VarContext> ctx);

--- a/src/expression/constraint.cpp
+++ b/src/expression/constraint.cpp
@@ -259,7 +259,7 @@ Constraint operator>(cst_t left, Expr right)
 
 Constraint ULE(Expr left, Expr right)
 {
-    return std::make_shared<ConstraintObject>(ConstraintType::ULE, right, left);
+    return std::make_shared<ConstraintObject>(ConstraintType::ULE, left, right);
 }
 
 Constraint ULE(Expr left, ucst_t right)
@@ -274,7 +274,7 @@ Constraint ULE(ucst_t left, Expr right)
 
 Constraint ULT(Expr left, Expr right)
 {
-    return std::make_shared<ConstraintObject>(ConstraintType::ULT, right, left);
+    return std::make_shared<ConstraintObject>(ConstraintType::ULT, left, right);
 }
 
 Constraint ULT(Expr left, ucst_t right)


### PR DESCRIPTION
Allow to create constraints that consist of *unsigned* comparisons of abstract values