### PR TITLE
Use  `MemMapManager` to detect free space in memory instead of page permissions

### DIFF
--- a/src/include/maat/memory_page.hpp
+++ b/src/include/maat/memory_page.hpp
@@ -120,6 +120,7 @@ public:
 public:
     void map(MemMap map);
     void unmap(addr_t start, addr_t end);
+    bool is_free(addr_t start, addr_t end) const;
 public:
     const std::list<MemMap>& get_maps() const;
     void set_maps(std::list<MemMap>&&);

--- a/src/loader/loader_lief.cpp
+++ b/src/loader/loader_lief.cpp
@@ -116,8 +116,7 @@ addr_t LoaderLIEF::alloc_segment(
     addr_t size,
     mem_flag_t flags,
     const std::string& name
-)
-{
+){
     try
     {
         return engine->mem->allocate(prefered_base, size, 0x1000, flags, name);

--- a/src/memory/memory.cpp
+++ b/src/memory/memory.cpp
@@ -1672,7 +1672,7 @@ addr_t MemEngine::allocate(
 
     while (base <= max_addr-size+1)
     {
-        if (page_manager.is_unmapped(base, base+size-1))
+        if (mappings.is_free(base, base+size-1))
         {
             map(base, base+size-1, flags, name);
             return base;
@@ -1710,7 +1710,7 @@ std::shared_ptr<MemSegment> MemEngine::get_segment_containing(addr_t addr)
 
 bool MemEngine::is_free(addr_t start, addr_t end)
 {
-    return page_manager.is_unmapped(start, end);
+    return mappings.is_free(start, end);
 }
 
 addr_t MemEngine::allocate_segment(

--- a/src/memory/memory_map.cpp
+++ b/src/memory/memory_map.cpp
@@ -147,6 +147,14 @@ const MemMap& MemMapManager::get_map_by_name(const std::string& name) const
     );
 }
 
+bool MemMapManager::is_free(addr_t start, addr_t end) const
+{
+    for (const MemMap& map : _maps)
+        if (map.intersects_with_range(start, end))
+            return false;
+    return true;
+}
+
 std::ostream& operator<<(std::ostream& os, const MemMapManager& mem)
 {
     static unsigned int addr_w = 20;


### PR DESCRIPTION
Fixes #147 