### PR TITLE
Migrate to Trusted Publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -168,6 +168,11 @@ jobs:
     name: upload wheels to PyPI
     runs-on: ubuntu-latest
     needs: [build_wheels_linux, build_wheels_macos]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pymaat
+    permissions:
+      id-token: write
     strategy:
       matrix:
         # The os names must match the ones in the build_wheels job
@@ -182,8 +187,5 @@ jobs:
           path: ${{ matrix.os }}-wheels/
 
       - name: "Upload wheels"
-        uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: ${{ matrix.os }}-wheels/
+        uses: pypa/gh-action-pypi-publish@release/v1
+          packages-dir: ${{ matrix.os }}-wheels/


### PR DESCRIPTION
This PR adapts the PyPI publishing workflow to use Trusted Publishing. 

I've also created the corresponding trusted publisher on PyPI:
<img width="591" height="121" alt="image" src="https://github.com/user-attachments/assets/278059c3-7691-4b93-bf3b-9d6da354e1b5" />
